### PR TITLE
Recreate design elements in new folder

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -1,0 +1,282 @@
+# FinverPro - Designs do Sistema
+
+Este diretório contém todos os designs HTML/CSS/JS criados para o sistema FinverPro, baseados no template fornecido e adaptados para as funcionalidades específicas da plataforma.
+
+## 📁 Estrutura dos Designs
+
+```
+design/
+├── dashboard/           # Dashboard principal
+├── roleta/             # Roleta da sorte
+├── investimentos/      # Produtos e investimentos
+├── equipe/             # Indicações e equipe
+├── perfil/             # Perfil do usuário
+├── relatorios/         # Relatórios e estatísticas
+└── assets/             # Recursos compartilhados
+    ├── css/
+    ├── js/
+    └── images/
+```
+
+## 🎨 Design System
+
+### Cores
+- **Primária**: `#0F172A` (Slate 900)
+- **Secundária**: `#1E293B` (Slate 800)
+- **Accent**: `#3B82F6` (Blue 500)
+- **Sucesso**: `#059669` (Emerald 600)
+- **Aviso**: `#D97706` (Amber 600)
+- **Erro**: `#DC2626` (Red 600)
+- **Roxo**: `#8B5CF6` (Violet 500)
+
+### Tipografia
+- **Principal**: Inter (sistema)
+- **Secundária**: Roboto (números e títulos)
+
+### Breakpoints
+- **Desktop**: > 1024px
+- **Tablet**: ≤ 1024px
+- **Mobile**: ≤ 768px
+
+## 📱 Funcionalidades dos Designs
+
+### 1. Dashboard (`/dashboard/`)
+**Características:**
+- Visão geral do patrimônio
+- Cards de estatísticas animados
+- Gráficos interativos
+- Ações rápidas
+- Menu lateral responsivo
+
+**Elementos incluídos:**
+- Saldo total e distribuição
+- Últimos investimentos
+- Indicações recentes
+- Atalhos para principais funcionalidades
+
+### 2. Roleta da Sorte (`/roleta/`)
+**Características:**
+- Roleta animada em CSS/JS
+- Sistema de premiação
+- Histórico de prêmios
+- Moedas/pontos do usuário
+- Animações fluidas
+
+**Elementos incluídos:**
+- Roleta visual interativa
+- Botão de girar com animações
+- Lista de prêmios disponíveis
+- Histórico de vitórias
+
+### 3. Investimentos (`/investimentos/`)
+**Características:**
+- Catálogo de produtos
+- Modal de investimento
+- Meus investimentos ativos
+- Calculadora de rendimento
+- Status em tempo real
+
+**Elementos incluídos:**
+- Cards de produtos com informações detalhadas
+- Sistema de filtros
+- Modal para realizar investimentos
+- Tabela de investimentos ativos
+
+### 4. Equipe (`/equipe/`)
+**Características:**
+- Programa de indicações
+- Código de referência
+- Lista da rede
+- Níveis de comissão
+- Compartilhamento social
+
+**Elementos incluídos:**
+- Card do código de indicação
+- Botões de compartilhamento
+- Tabela de indicados
+- Sistema de filtros
+- Níveis de comissão (Bronze, Prata, Ouro, Diamante)
+
+### 5. Perfil (`/perfil/`)
+**Características:**
+- Informações pessoais
+- Configurações de segurança
+- Preferências de notificação
+- Histórico de atividades
+- Upload de avatar
+
+**Elementos incluídos:**
+- Tabs de navegação
+- Formulários de edição
+- Toggle switches
+- Sistema de notificações toast
+- Log de atividades
+
+### 6. Relatórios (`/relatorios/`)
+**Características:**
+- Gráficos interativos (Chart.js)
+- Métricas de performance
+- Filtros de período
+- Exportação de relatórios
+- Tabelas de transações
+
+**Elementos incluídos:**
+- Gráfico de evolução patrimonial
+- Gráfico de distribuição de carteira
+- Cards de performance
+- Tabela de transações
+- Seletores de período
+
+## 🔧 Tecnologias Utilizadas
+
+### Frontend
+- **HTML5**: Estrutura semântica
+- **CSS3**: Estilização moderna com CSS Variables
+- **JavaScript ES6+**: Interatividade
+- **Chart.js**: Gráficos e visualizações
+- **Font Awesome**: Ícones
+- **Google Fonts**: Tipografia (Inter + Roboto)
+
+### Recursos
+- **CSS Grid & Flexbox**: Layout responsivo
+- **CSS Variables**: Sistema de cores dinâmico
+- **CSS Animations**: Transições suaves
+- **LocalStorage**: Persistência de dados (simulada)
+- **Fetch API**: Simulação de requisições
+
+## 📱 Responsividade
+
+Todos os designs são totalmente responsivos e incluem:
+
+### Desktop (> 1024px)
+- Sidebar fixa
+- Layout em grid completo
+- Hover effects
+- Tooltips avançados
+
+### Tablet/Mobile (≤ 1024px)
+- Sidebar colapsável
+- Menu hamburger
+- Layout em coluna única
+- Touch-friendly buttons
+- Gestos de swipe (onde aplicável)
+
+## 🎯 Padrões de UX/UI
+
+### Navegação
+- Sidebar consistente em todas as páginas
+- Breadcrumbs para orientação
+- Estados ativos claramente identificados
+- Transições suaves entre páginas
+
+### Feedback Visual
+- Loading states
+- Animações de sucesso/erro
+- Progress indicators
+- Tooltips informativos
+
+### Acessibilidade
+- Contraste adequado (WCAG AA)
+- Navegação por teclado
+- Labels descritivos
+- Foco visível
+
+## 🚀 Como Implementar
+
+### 1. Integração com Backend
+```javascript
+// Exemplo de integração API
+const API_BASE = 'https://api.finverpro.com';
+
+async function fetchUserData() {
+    const response = await fetch(`${API_BASE}/user`);
+    return response.json();
+}
+```
+
+### 2. Autenticação
+```javascript
+// Sistema de autenticação
+function checkAuth() {
+    const token = localStorage.getItem('authToken');
+    if (!token) {
+        window.location.href = '/login';
+    }
+}
+```
+
+### 3. Dados Dinâmicos
+Os designs incluem dados simulados que podem ser facilmente substituídos por dados reais da API:
+
+```javascript
+// Substituir dados simulados
+const mockData = {
+    balance: 52847.32,
+    investments: [...],
+    referrals: [...]
+};
+
+// Por dados da API
+const realData = await fetchDashboardData();
+```
+
+## 🔧 Customização
+
+### Cores
+Edite as CSS Variables no `:root` para personalizar o tema:
+
+```css
+:root {
+    --accent: #3B82F6;        /* Cor principal */
+    --success: #059669;       /* Cor de sucesso */
+    --warning: #D97706;       /* Cor de aviso */
+    --danger: #DC2626;        /* Cor de erro */
+}
+```
+
+### Tema Escuro
+Todos os designs incluem suporte a tema escuro via atributo `data-theme="dark"`.
+
+### Componentes
+Os componentes são modulares e podem ser reutilizados:
+
+```html
+<!-- Card padrão -->
+<div class="stat-card">
+    <div class="stat-icon">
+        <i class="fas fa-chart-line"></i>
+    </div>
+    <div class="stat-value">R$ 52.847</div>
+    <div class="stat-label">Patrimônio Total</div>
+</div>
+```
+
+## 📋 Checklist de Implementação
+
+- [ ] Configurar API endpoints
+- [ ] Implementar autenticação
+- [ ] Conectar dados reais
+- [ ] Configurar notificações
+- [ ] Implementar upload de arquivos
+- [ ] Configurar sistema de pagamentos
+- [ ] Testes de responsividade
+- [ ] Testes de acessibilidade
+- [ ] Otimização de performance
+- [ ] Deploy e configuração de domínio
+
+## 🤝 Suporte
+
+Para dúvidas sobre implementação ou customização dos designs:
+
+1. Consulte a documentação inline nos arquivos HTML
+2. Verifique os comentários no CSS para entender a estrutura
+3. Teste todas as funcionalidades em diferentes dispositivos
+4. Valide a acessibilidade com ferramentas apropriadas
+
+## 📄 Licença
+
+Estes designs foram criados especificamente para o projeto FinverPro e devem ser usados conforme acordado.
+
+---
+
+**Nota**: Os designs incluem dados simulados para demonstração. Na implementação real, substitua por dados dinâmicos da API do sistema.

--- a/design/dashboard/index.html
+++ b/design/dashboard/index.html
@@ -1,0 +1,1169 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FinverPro - Dashboard</title>
+    
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Roboto:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    
+    <style>
+        :root {
+            --bg-primary: #F8FAFC;
+            --bg-secondary: #FFFFFF;
+            --bg-sidebar: #1E293B;
+            --bg-card: #FFFFFF;
+            --bg-header: #FFFFFF;
+            
+            --primary: #0F172A;
+            --primary-light: #334155;
+            --accent: #3B82F6;
+            --success: #059669;
+            --warning: #D97706;
+            --danger: #DC2626;
+            
+            --text-primary: #0F172A;
+            --text-secondary: #64748B;
+            --text-muted: #94A3B8;
+            --text-white: #FFFFFF;
+            
+            --border: #E2E8F0;
+            --border-light: #F1F5F9;
+            
+            --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+            
+            --radius: 8px;
+            --radius-lg: 12px;
+        }
+
+        [data-theme="dark"] {
+            --bg-primary: #0F172A;
+            --bg-secondary: #1E293B;
+            --bg-sidebar: #0F172A;
+            --bg-card: #1E293B;
+            --bg-header: #1E293B;
+            
+            --primary: #F8FAFC;
+            --primary-light: #E2E8F0;
+            --accent: #3B82F6;
+            --success: #10B981;
+            --warning: #F59E0B;
+            --danger: #EF4444;
+            
+            --text-primary: #F8FAFC;
+            --text-secondary: #94A3B8;
+            --text-muted: #64748B;
+            --text-white: #FFFFFF;
+            
+            --border: #334155;
+            --border-light: #475569;
+            
+            --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3);
+            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.3);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Inter', sans-serif;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            line-height: 1.5;
+            display: flex;
+            min-height: 100vh;
+            transition: all 0.3s ease;
+        }
+
+        /* Fixed Header */
+        .fixed-header {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            background: var(--bg-header);
+            border-bottom: 1px solid var(--border);
+            padding: 16px 24px;
+            z-index: 1000;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            box-shadow: var(--shadow);
+        }
+
+        .header-left {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+        }
+
+        .hamburger {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            width: 40px;
+            height: 40px;
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            cursor: pointer;
+            box-shadow: var(--shadow);
+        }
+
+        .header-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: var(--text-primary);
+            font-family: 'Roboto', sans-serif;
+        }
+
+        .language-selector {
+            position: relative;
+            display: inline-block;
+        }
+
+        .language-btn {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            padding: 8px 16px;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--text-primary);
+            transition: all 0.2s ease;
+            box-shadow: var(--shadow);
+        }
+
+        .language-btn:hover {
+            background: var(--bg-primary);
+            border-color: var(--accent);
+        }
+
+        .language-dropdown {
+            position: absolute;
+            top: 100%;
+            right: 0;
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            box-shadow: var(--shadow-lg);
+            min-width: 140px;
+            opacity: 0;
+            visibility: hidden;
+            transform: translateY(-10px);
+            transition: all 0.3s ease;
+            z-index: 1001;
+        }
+
+        .language-dropdown.show {
+            opacity: 1;
+            visibility: visible;
+            transform: translateY(0);
+        }
+
+        .language-option {
+            padding: 12px 16px;
+            cursor: pointer;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 14px;
+            color: var(--text-primary);
+            transition: all 0.2s ease;
+        }
+
+        .language-option:hover {
+            background: var(--bg-primary);
+        }
+
+        .language-option.active {
+            background: var(--accent);
+            color: white;
+        }
+
+        /* Sidebar */
+        .sidebar {
+            width: 280px;
+            background: var(--bg-sidebar);
+            color: var(--text-white);
+            padding: 0;
+            position: fixed;
+            height: 100vh;
+            left: 0;
+            top: 72px;
+            z-index: 100;
+            display: flex;
+            flex-direction: column;
+            box-shadow: var(--shadow-lg);
+            transition: all 0.3s ease;
+        }
+
+        .sidebar-content {
+            flex: 1;
+            overflow-y: auto;
+            padding: 24px 0;
+        }
+
+        .nav-section {
+            margin-bottom: 32px;
+        }
+
+        .nav-section-title {
+            font-size: 12px;
+            font-weight: 600;
+            color: rgba(255, 255, 255, 0.5);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 16px;
+            padding: 0 24px;
+        }
+
+        .nav-item {
+            display: flex;
+            align-items: center;
+            padding: 12px 24px;
+            color: rgba(255, 255, 255, 0.8);
+            text-decoration: none;
+            transition: all 0.2s ease;
+            font-weight: 500;
+            border-right: 3px solid transparent;
+        }
+
+        .nav-item:hover {
+            background: rgba(255, 255, 255, 0.05);
+            color: var(--text-white);
+        }
+
+        .nav-item.active {
+            background: rgba(59, 130, 246, 0.1);
+            color: #3B82F6;
+            border-right-color: #3B82F6;
+        }
+
+        .nav-item i {
+            width: 20px;
+            margin-right: 12px;
+            font-size: 16px;
+        }
+
+        .sidebar-footer {
+            padding: 24px;
+            border-top: 1px solid rgba(255, 255, 255, 0.1);
+        }
+
+        .sidebar-footer .nav-item {
+            padding: 12px 0;
+            margin-bottom: 8px;
+        }
+
+        .sidebar-footer .nav-item:last-child {
+            margin-bottom: 0;
+            color: #EF4444;
+        }
+
+        .sidebar-footer .nav-item:last-child:hover {
+            background: rgba(239, 68, 68, 0.1);
+        }
+
+        .theme-toggle {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 12px 0;
+            margin-bottom: 8px;
+            color: rgba(255, 255, 255, 0.8);
+        }
+
+        .theme-switch {
+            position: relative;
+            width: 50px;
+            height: 24px;
+            background: rgba(255, 255, 255, 0.2);
+            border-radius: 12px;
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+
+        .theme-switch.dark {
+            background: var(--accent);
+        }
+
+        .theme-switch::before {
+            content: '';
+            position: absolute;
+            width: 20px;
+            height: 20px;
+            background: white;
+            border-radius: 50%;
+            top: 2px;
+            left: 2px;
+            transition: all 0.3s ease;
+        }
+
+        .theme-switch.dark::before {
+            transform: translateX(26px);
+        }
+
+        /* Main content */
+        .main-content {
+            flex: 1;
+            margin-left: 280px;
+            margin-top: 72px;
+            padding: 32px;
+            max-width: calc(100vw - 280px);
+        }
+
+        /* Header */
+        .header {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px 32px;
+            margin-bottom: 32px;
+            box-shadow: var(--shadow);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .header-left h1 {
+            font-size: 28px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+            font-family: 'Roboto', sans-serif;
+        }
+
+        .header-left p {
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
+        .header-right {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+        }
+
+        /* Balance section */
+        .balance-section {
+            display: grid;
+            grid-template-columns: 2fr 1fr;
+            gap: 24px;
+            margin-bottom: 32px;
+        }
+
+        .balance-card {
+            background: linear-gradient(135deg, var(--primary), var(--primary-light));
+            color: white;
+            border-radius: var(--radius-lg);
+            padding: 32px;
+            box-shadow: var(--shadow-md);
+            position: relative;
+            overflow: hidden;
+        }
+
+        .balance-card::before {
+            content: '';
+            position: absolute;
+            top: -50px;
+            right: -50px;
+            width: 100px;
+            height: 100px;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 50%;
+        }
+
+        .balance-label {
+            font-size: 14px;
+            font-weight: 500;
+            opacity: 0.9;
+            margin-bottom: 8px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .balance-amount {
+            font-size: 42px;
+            font-weight: 700;
+            margin-bottom: 8px;
+            font-family: 'Roboto', sans-serif;
+        }
+
+        .balance-subtitle {
+            font-size: 14px;
+            opacity: 0.8;
+        }
+
+        .actions-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            box-shadow: var(--shadow);
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+
+        .actions-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 8px;
+        }
+
+        .action-btn {
+            background: var(--accent);
+            color: white;
+            border: none;
+            padding: 16px 20px;
+            border-radius: var(--radius);
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 8px;
+            font-size: 14px;
+            text-decoration: none;
+        }
+
+        .action-btn:hover {
+            background: #2563EB;
+            transform: translateY(-1px);
+            color: white;
+        }
+
+        .action-btn.secondary {
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            border: 1px solid var(--border);
+        }
+
+        .action-btn.secondary:hover {
+            background: #F1F5F9;
+        }
+
+        /* Quick Stats */
+        .quick-stats {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            margin-bottom: 32px;
+        }
+
+        .stat-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            box-shadow: var(--shadow);
+            transition: all 0.2s ease;
+        }
+
+        .stat-card:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-md);
+        }
+
+        .stat-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 16px;
+        }
+
+        .stat-icon {
+            width: 48px;
+            height: 48px;
+            background: rgba(59, 130, 246, 0.1);
+            color: var(--accent);
+            border-radius: var(--radius);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 20px;
+        }
+
+        .stat-trend {
+            background: var(--success);
+            color: white;
+            padding: 4px 8px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 600;
+        }
+
+        .stat-value {
+            font-size: 24px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+        }
+
+        .stat-label {
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
+        /* Investments */
+        .investments-section {
+            margin-bottom: 32px;
+        }
+
+        .section-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 24px;
+        }
+
+        .section-title {
+            font-size: 22px;
+            font-weight: 600;
+            color: var(--text-primary);
+        }
+
+        .view-all {
+            color: var(--accent);
+            text-decoration: none;
+            font-weight: 500;
+            font-size: 14px;
+        }
+
+        .investments-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 20px;
+        }
+
+        .investment-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            box-shadow: var(--shadow);
+            transition: all 0.2s ease;
+            cursor: pointer;
+            text-decoration: none;
+            color: var(--text-primary);
+        }
+
+        .investment-card:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-md);
+            border-color: var(--accent);
+            color: var(--text-primary);
+        }
+
+        .investment-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 16px;
+        }
+
+        .investment-icon {
+            width: 48px;
+            height: 48px;
+            background: rgba(59, 130, 246, 0.1);
+            color: var(--accent);
+            border-radius: var(--radius);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 20px;
+        }
+
+        .investment-return {
+            background: var(--success);
+            color: white;
+            padding: 6px 12px;
+            border-radius: 16px;
+            font-size: 12px;
+            font-weight: 600;
+        }
+
+        .investment-name {
+            font-size: 18px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 8px;
+        }
+
+        .investment-details {
+            color: var(--text-secondary);
+            font-size: 14px;
+            margin-bottom: 16px;
+        }
+
+        .investment-amount {
+            font-size: 16px;
+            font-weight: 600;
+            color: var(--text-primary);
+        }
+
+        /* Services */
+        .services-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+        }
+
+        .service-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            text-align: center;
+            text-decoration: none;
+            color: var(--text-primary);
+            transition: all 0.2s ease;
+            box-shadow: var(--shadow);
+        }
+
+        .service-card:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-md);
+            border-color: var(--accent);
+            color: var(--text-primary);
+        }
+
+        .service-icon {
+            width: 56px;
+            height: 56px;
+            background: rgba(59, 130, 246, 0.1);
+            color: var(--accent);
+            border-radius: var(--radius);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0 auto 16px;
+            font-size: 24px;
+        }
+
+        .service-title {
+            font-size: 16px;
+            font-weight: 600;
+            margin-bottom: 8px;
+        }
+
+        .service-description {
+            font-size: 14px;
+            color: var(--text-secondary);
+        }
+
+        /* Toast */
+        .toast {
+            position: fixed;
+            top: 96px;
+            right: 24px;
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 16px 20px;
+            box-shadow: var(--shadow-lg);
+            z-index: 1000;
+            opacity: 0;
+            transform: translateX(100px);
+            transition: all 0.3s ease;
+            min-width: 300px;
+        }
+
+        .toast.show {
+            opacity: 1;
+            transform: translateX(0);
+        }
+
+        .toast.success {
+            border-left: 4px solid var(--success);
+        }
+
+        .toast.error {
+            border-left: 4px solid var(--danger);
+        }
+
+        .toast.info {
+            border-left: 4px solid var(--accent);
+        }
+
+        /* Responsive */
+        @media (max-width: 1024px) {
+            .sidebar {
+                transform: translateX(-100%);
+                transition: transform 0.3s ease;
+            }
+            
+            .sidebar.open {
+                transform: translateX(0);
+            }
+            
+            .main-content {
+                margin-left: 0;
+                max-width: 100vw;
+                padding: 20px;
+            }
+            
+            .balance-section {
+                grid-template-columns: 1fr;
+            }
+            
+            .hamburger {
+                display: flex;
+            }
+        }
+
+        /* Animations */
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+        }
+    </style>
+</head>
+
+<body>
+    <!-- Fixed Header -->
+    <header class="fixed-header">
+        <div class="header-left">
+            <button class="hamburger" onclick="toggleSidebar()">
+                <i class="fas fa-bars"></i>
+            </button>
+            <div class="header-title">FinverPro</div>
+        </div>
+        
+        <div class="language-selector">
+            <button class="language-btn" onclick="toggleLanguageDropdown()">
+                <i class="fas fa-globe"></i>
+                <span id="current-language">Português</span>
+                <i class="fas fa-chevron-down"></i>
+            </button>
+            
+            <div class="language-dropdown" id="language-dropdown">
+                <div class="language-option active" onclick="changeLanguage('pt', 'Português')">
+                    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiByeD0iMiIgZmlsbD0iIzAwOTczOSIvPgo8cmVjdCB5PSI4IiB3aWR0aD0iMjQiIGhlaWdodD0iOCIgZmlsbD0iI0ZGRkYwMCIvPgo8Y2lyY2xlIGN4PSI5IiBjeT0iMTIiIHI9IjMuNSIgZmlsbD0iIzAwMjc2OCIvPgo8L3N2Zz4=" alt="PT" width="20" height="14">
+                    Português
+                </div>
+                <div class="language-option" onclick="changeLanguage('en', 'English')">
+                    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiByeD0iMiIgZmlsbD0iIzAwNTJCNCIvPgo8cmVjdCB5PSI5IiB3aWR0aD0iMjQiIGhlaWdodD0iMS41IiBmaWxsPSIjRkZGRkZGIi8+CjxyZWN0IHk9IjEzLjUiIHdpZHRoPSIyNCIgaGVpZ2h0PSIxLjUiIGZpbGw9IiNGRkZGRkYiLz4KPC9zdmc+" alt="EN" width="20" height="14">
+                    English
+                </div>
+                <div class="language-option" onclick="changeLanguage('es', 'Español')">
+                    <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIHZpZXdCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiByeD0iMiIgZmlsbD0iI0FBMTUyQSIvPgo8cmVjdCB5PSI2IiB3aWR0aD0iMjQiIGhlaWdodD0iMTIiIGZpbGw9IiNGRkM0MDAiLz4KPC9zdmc+" alt="ES" width="20" height="14">
+                    Español
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <!-- Sidebar -->
+    <nav class="sidebar" id="sidebar">
+        <div class="sidebar-content">
+            <div class="nav-section">
+                <div class="nav-section-title">Básico</div>
+                <a href="#" class="nav-item active">
+                    <i class="fas fa-home"></i>
+                    Início
+                </a>
+                <a href="../equipe/" class="nav-item">
+                    <i class="fas fa-users"></i>
+                    Equipe
+                </a>
+                <a href="../perfil/" class="nav-item">
+                    <i class="fas fa-user-circle"></i>
+                    Perfil
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Investimentos</div>
+                <a href="../investimentos/" class="nav-item">
+                    <i class="fas fa-coins"></i>
+                    Produtos
+                </a>
+                <a href="../investimentos/" class="nav-item">
+                    <i class="fas fa-chart-line"></i>
+                    Meus Investimentos
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Diversão</div>
+                <a href="../roleta/" class="nav-item">
+                    <i class="fas fa-magic"></i>
+                    Roleta da Sorte
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Estatísticas</div>
+                <a href="../relatorios/" class="nav-item">
+                    <i class="fas fa-chart-bar"></i>
+                    Relatórios
+                </a>
+            </div>
+        </div>
+
+        <div class="sidebar-footer">
+            <div class="theme-toggle">
+                <div style="display: flex; align-items: center; gap: 8px;">
+                    <i class="fas fa-moon"></i>
+                    <span>Modo Escuro</span>
+                </div>
+                <div class="theme-switch" id="theme-switch" onclick="toggleTheme()"></div>
+            </div>
+            
+            <a href="#" class="nav-item" onclick="showToast('Abrindo configurações...', 'info')">
+                <i class="fas fa-cog"></i>
+                Configurações
+            </a>
+            <a href="#" class="nav-item" onclick="showToast('Desconectando...', 'info')">
+                <i class="fas fa-sign-out-alt"></i>
+                Sair
+            </a>
+        </div>
+    </nav>
+
+    <!-- Main Content -->
+    <main class="main-content">
+        <!-- Header -->
+        <div class="header">
+            <div class="header-left">
+                <h1>Dashboard</h1>
+                <p>Bem-vindo de volta, Investidor</p>
+            </div>
+        </div>
+
+        <!-- Balance Section -->
+        <section class="balance-section">
+            <div class="balance-card">
+                <div class="balance-label">Patrimônio Total</div>
+                <div class="balance-amount">R$ 127.548,92</div>
+                <div class="balance-subtitle">Disponível para investir: R$ 12.547,89</div>
+            </div>
+            
+            <div class="actions-card">
+                <h3 class="actions-title">Ações Rápidas</h3>
+                <a href="../investimentos/" class="action-btn">
+                    <i class="fas fa-plus"></i>
+                    Investir
+                </a>
+                <a href="../roleta/" class="action-btn secondary">
+                    <i class="fas fa-magic"></i>
+                    Roleta da Sorte
+                </a>
+            </div>
+        </section>
+
+        <!-- Quick Stats -->
+        <section class="quick-stats">
+            <div class="stat-card">
+                <div class="stat-header">
+                    <div class="stat-icon">
+                        <i class="fas fa-chart-line"></i>
+                    </div>
+                    <div class="stat-trend">+15.2%</div>
+                </div>
+                <div class="stat-value">R$ 45.280</div>
+                <div class="stat-label">Investimentos Ativos</div>
+            </div>
+
+            <div class="stat-card">
+                <div class="stat-header">
+                    <div class="stat-icon">
+                        <i class="fas fa-coins"></i>
+                    </div>
+                    <div class="stat-trend">+8.7%</div>
+                </div>
+                <div class="stat-value">R$ 3.842</div>
+                <div class="stat-label">Rendimento Mensal</div>
+            </div>
+
+            <div class="stat-card">
+                <div class="stat-header">
+                    <div class="stat-icon">
+                        <i class="fas fa-users"></i>
+                    </div>
+                    <div class="stat-trend">+12</div>
+                </div>
+                <div class="stat-value">156</div>
+                <div class="stat-label">Equipe Total</div>
+            </div>
+
+            <div class="stat-card">
+                <div class="stat-header">
+                    <div class="stat-icon">
+                        <i class="fas fa-gift"></i>
+                    </div>
+                    <div class="stat-trend">5</div>
+                </div>
+                <div class="stat-value">R$ 245</div>
+                <div class="stat-label">Bônus da Roleta</div>
+            </div>
+        </section>
+
+        <!-- Investments Section -->
+        <section class="investments-section">
+            <div class="section-header">
+                <h2 class="section-title">Investimentos em Destaque</h2>
+                <a href="../investimentos/" class="view-all">Ver todos</a>
+            </div>
+            
+            <div class="investments-grid">
+                <a href="../investimentos/" class="investment-card">
+                    <div class="investment-header">
+                        <div class="investment-icon">
+                            <i class="fas fa-chart-line"></i>
+                        </div>
+                        <div class="investment-return">15.2% a.a.</div>
+                    </div>
+                    <div class="investment-name">Renda Fixa Premium</div>
+                    <div class="investment-details">Investimento mínimo: R$ 1.000</div>
+                    <div class="investment-amount">Valor atual: R$ 1.152</div>
+                </a>
+
+                <a href="../investimentos/" class="investment-card">
+                    <div class="investment-header">
+                        <div class="investment-icon">
+                            <i class="fas fa-trending-up"></i>
+                        </div>
+                        <div class="investment-return">18.7% a.a.</div>
+                    </div>
+                    <div class="investment-name">Multi Plus</div>
+                    <div class="investment-details">Investimento mínimo: R$ 5.000</div>
+                    <div class="investment-amount">Valor atual: R$ 5.935</div>
+                </a>
+
+                <a href="../investimentos/" class="investment-card">
+                    <div class="investment-header">
+                        <div class="investment-icon">
+                            <i class="fas fa-gem"></i>
+                        </div>
+                        <div class="investment-return">22.1% a.a.</div>
+                    </div>
+                    <div class="investment-name">Elite Invest</div>
+                    <div class="investment-details">Investimento mínimo: R$ 10.000</div>
+                    <div class="investment-amount">Valor atual: R$ 12.210</div>
+                </a>
+            </div>
+        </section>
+
+        <!-- Services Section -->
+        <section class="services-section">
+            <div class="section-header">
+                <h2 class="section-title">Serviços</h2>
+            </div>
+            
+            <div class="services-grid">
+                <a href="../roleta/" class="service-card">
+                    <div class="service-icon">
+                        <i class="fas fa-magic"></i>
+                    </div>
+                    <div class="service-title">Roleta da Sorte</div>
+                    <div class="service-description">Gire e ganhe prêmios incríveis todos os dias</div>
+                </a>
+
+                <a href="../equipe/" class="service-card">
+                    <div class="service-icon">
+                        <i class="fas fa-users"></i>
+                    </div>
+                    <div class="service-title">Programa de Indicação</div>
+                    <div class="service-description">Indique amigos e ganhe comissões por vida</div>
+                </a>
+
+                <a href="../relatorios/" class="service-card">
+                    <div class="service-icon">
+                        <i class="fas fa-chart-pie"></i>
+                    </div>
+                    <div class="service-title">Relatórios Detalhados</div>
+                    <div class="service-description">Acompanhe seu desempenho em tempo real</div>
+                </a>
+
+                <a href="../perfil/" class="service-card">
+                    <div class="service-icon">
+                        <i class="fas fa-user-cog"></i>
+                    </div>
+                    <div class="service-title">Configurações</div>
+                    <div class="service-description">Personalize sua experiência na plataforma</div>
+                </a>
+            </div>
+        </section>
+    </main>
+
+    <script>
+        // Theme management
+        let currentTheme = 'light';
+        
+        function toggleTheme() {
+            currentTheme = currentTheme === 'light' ? 'dark' : 'light';
+            document.documentElement.setAttribute('data-theme', currentTheme);
+            document.getElementById('theme-switch').classList.toggle('dark');
+            
+            // Update theme icon and text
+            const themeToggle = document.querySelector('.theme-toggle');
+            const icon = themeToggle.querySelector('i');
+            const text = themeToggle.querySelector('span');
+            
+            if (currentTheme === 'dark') {
+                icon.className = 'fas fa-sun';
+                text.textContent = 'Modo Claro';
+            } else {
+                icon.className = 'fas fa-moon';
+                text.textContent = 'Modo Escuro';
+            }
+            
+            showToast(`Modo ${currentTheme === 'dark' ? 'escuro' : 'claro'} ativado`, 'success');
+        }
+
+        // Language management
+        function toggleLanguageDropdown() {
+            const dropdown = document.getElementById('language-dropdown');
+            dropdown.classList.toggle('show');
+        }
+
+        function changeLanguage(lang, langName) {
+            document.getElementById('current-language').textContent = langName;
+            document.querySelectorAll('.language-option').forEach(option => {
+                option.classList.remove('active');
+            });
+            event.target.classList.add('active');
+            
+            // Close dropdown
+            document.getElementById('language-dropdown').classList.remove('show');
+            
+            showToast(`Idioma alterado para ${langName}`, 'success');
+        }
+
+        // Close language dropdown when clicking outside
+        document.addEventListener('click', function(event) {
+            const languageSelector = document.querySelector('.language-selector');
+            if (!languageSelector.contains(event.target)) {
+                document.getElementById('language-dropdown').classList.remove('show');
+            }
+        });
+
+        // Sidebar toggle for mobile
+        function toggleSidebar() {
+            const sidebar = document.getElementById('sidebar');
+            sidebar.classList.toggle('open');
+        }
+
+        // Close sidebar when clicking outside on mobile
+        document.addEventListener('click', function(event) {
+            const sidebar = document.getElementById('sidebar');
+            const hamburger = document.querySelector('.hamburger');
+            
+            if (window.innerWidth <= 1024 && !sidebar.contains(event.target) && !hamburger.contains(event.target)) {
+                sidebar.classList.remove('open');
+            }
+        });
+
+        // Toast notification system
+        function showToast(message, type = 'success', duration = 4000) {
+            // Remove existing toasts
+            const existingToasts = document.querySelectorAll('.toast');
+            existingToasts.forEach(toast => toast.remove());
+
+            const toast = document.createElement('div');
+            toast.className = `toast ${type}`;
+            
+            toast.innerHTML = `
+                <div style="display: flex; align-items: center; gap: 12px;">
+                    <i class="fas ${type === 'success' ? 'fa-check-circle' : type === 'error' ? 'fa-exclamation-circle' : 'fa-info-circle'}" style="color: var(--${type === 'success' ? 'success' : type === 'error' ? 'danger' : 'accent'});"></i>
+                    <span style="flex: 1; font-size: 14px; font-weight: 500;">${message}</span>
+                    <button onclick="this.parentElement.parentElement.remove()" style="background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 0; font-size: 16px;">
+                        <i class="fas fa-times"></i>
+                    </button>
+                </div>
+            `;
+            
+            document.body.appendChild(toast);
+            
+            // Show toast
+            setTimeout(() => {
+                toast.classList.add('show');
+            }, 100);
+            
+            // Auto remove toast
+            setTimeout(() => {
+                toast.classList.remove('show');
+                setTimeout(() => {
+                    toast.remove();
+                }, 300);
+            }, duration);
+        }
+
+        // Initialize theme on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            // Check for saved theme preference
+            const savedTheme = localStorage.getItem('theme') || 'light';
+            if (savedTheme === 'dark') {
+                toggleTheme();
+            }
+        });
+
+        // Navigation items click handling
+        document.querySelectorAll('.nav-item').forEach(item => {
+            item.addEventListener('click', function(e) {
+                if (this.getAttribute('href') === '#') {
+                    e.preventDefault();
+                }
+                
+                // Update active state
+                document.querySelectorAll('.nav-item').forEach(nav => nav.classList.remove('active'));
+                this.classList.add('active');
+            });
+        });
+
+        // Investment cards hover effect
+        document.querySelectorAll('.investment-card').forEach(card => {
+            card.addEventListener('mouseenter', function() {
+                this.style.transform = 'translateY(-4px)';
+            });
+            
+            card.addEventListener('mouseleave', function() {
+                this.style.transform = 'translateY(0)';
+            });
+        });
+
+        // Service cards hover effect
+        document.querySelectorAll('.service-card').forEach(card => {
+            card.addEventListener('mouseenter', function() {
+                this.style.transform = 'translateY(-4px)';
+            });
+            
+            card.addEventListener('mouseleave', function() {
+                this.style.transform = 'translateY(0)';
+            });
+        });
+
+        // Responsive handling
+        window.addEventListener('resize', function() {
+            const sidebar = document.getElementById('sidebar');
+            if (window.innerWidth > 1024) {
+                sidebar.classList.remove('open');
+            }
+        });
+
+        // Welcome message on page load
+        window.addEventListener('load', function() {
+            setTimeout(() => {
+                showToast('Bem-vindo ao FinverPro Dashboard!', 'success');
+            }, 1000);
+        });
+    </script>
+</body>
+</html>

--- a/design/equipe/index.html
+++ b/design/equipe/index.html
@@ -1,0 +1,1292 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FinverPro - Minha Equipe</title>
+    
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Roboto:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    
+    <style>
+        :root {
+            --bg-primary: #F8FAFC;
+            --bg-secondary: #FFFFFF;
+            --bg-sidebar: #1E293B;
+            --bg-card: #FFFFFF;
+            --bg-header: #FFFFFF;
+            
+            --primary: #0F172A;
+            --primary-light: #334155;
+            --accent: #3B82F6;
+            --success: #059669;
+            --warning: #D97706;
+            --danger: #DC2626;
+            --purple: #8B5CF6;
+            --pink: #EC4899;
+            --orange: #F97316;
+            
+            --text-primary: #0F172A;
+            --text-secondary: #64748B;
+            --text-muted: #94A3B8;
+            --text-white: #FFFFFF;
+            
+            --border: #E2E8F0;
+            --border-light: #F1F5F9;
+            
+            --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+            
+            --radius: 8px;
+            --radius-lg: 12px;
+        }
+
+        [data-theme="dark"] {
+            --bg-primary: #0F172A;
+            --bg-secondary: #1E293B;
+            --bg-sidebar: #0F172A;
+            --bg-card: #1E293B;
+            --bg-header: #1E293B;
+            
+            --primary: #F8FAFC;
+            --primary-light: #E2E8F0;
+            --accent: #3B82F6;
+            --success: #10B981;
+            --warning: #F59E0B;
+            --danger: #EF4444;
+            
+            --text-primary: #F8FAFC;
+            --text-secondary: #94A3B8;
+            --text-muted: #64748B;
+            --text-white: #FFFFFF;
+            
+            --border: #334155;
+            --border-light: #475569;
+            
+            --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3);
+            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.3);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Inter', sans-serif;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            line-height: 1.5;
+            display: flex;
+            min-height: 100vh;
+            transition: all 0.3s ease;
+        }
+
+        /* Fixed Header */
+        .fixed-header {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            background: var(--bg-header);
+            border-bottom: 1px solid var(--border);
+            padding: 16px 24px;
+            z-index: 1000;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            box-shadow: var(--shadow);
+        }
+
+        .header-left {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+        }
+
+        .hamburger {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            width: 40px;
+            height: 40px;
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            cursor: pointer;
+            box-shadow: var(--shadow);
+        }
+
+        .header-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: var(--text-primary);
+            font-family: 'Roboto', sans-serif;
+        }
+
+        /* Sidebar */
+        .sidebar {
+            width: 280px;
+            background: var(--bg-sidebar);
+            color: var(--text-white);
+            padding: 0;
+            position: fixed;
+            height: 100vh;
+            left: 0;
+            top: 72px;
+            z-index: 100;
+            display: flex;
+            flex-direction: column;
+            box-shadow: var(--shadow-lg);
+            transition: all 0.3s ease;
+        }
+
+        .sidebar-content {
+            flex: 1;
+            overflow-y: auto;
+            padding: 24px 0;
+        }
+
+        .nav-section {
+            margin-bottom: 32px;
+        }
+
+        .nav-section-title {
+            font-size: 12px;
+            font-weight: 600;
+            color: rgba(255, 255, 255, 0.5);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 16px;
+            padding: 0 24px;
+        }
+
+        .nav-item {
+            display: flex;
+            align-items: center;
+            padding: 12px 24px;
+            color: rgba(255, 255, 255, 0.8);
+            text-decoration: none;
+            transition: all 0.2s ease;
+            font-weight: 500;
+            border-right: 3px solid transparent;
+        }
+
+        .nav-item:hover {
+            background: rgba(255, 255, 255, 0.05);
+            color: var(--text-white);
+        }
+
+        .nav-item.active {
+            background: rgba(59, 130, 246, 0.1);
+            color: #3B82F6;
+            border-right-color: #3B82F6;
+        }
+
+        .nav-item i {
+            width: 20px;
+            margin-right: 12px;
+            font-size: 16px;
+        }
+
+        /* Main content */
+        .main-content {
+            flex: 1;
+            margin-left: 280px;
+            margin-top: 72px;
+            padding: 32px;
+            max-width: calc(100vw - 280px);
+        }
+
+        /* Header */
+        .header {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px 32px;
+            margin-bottom: 32px;
+            box-shadow: var(--shadow);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .header-left h1 {
+            font-size: 28px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+            font-family: 'Roboto', sans-serif;
+        }
+
+        .header-left p {
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
+        /* Stats Grid */
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            margin-bottom: 32px;
+        }
+
+        .stat-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            box-shadow: var(--shadow);
+            transition: all 0.2s ease;
+            text-align: center;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .stat-card:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-md);
+        }
+
+        .stat-card::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 4px;
+            background: linear-gradient(90deg, var(--accent), var(--success));
+        }
+
+        .stat-icon {
+            width: 48px;
+            height: 48px;
+            background: rgba(59, 130, 246, 0.1);
+            color: var(--accent);
+            border-radius: var(--radius);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0 auto 16px;
+            font-size: 20px;
+        }
+
+        .stat-value {
+            font-size: 24px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+        }
+
+        .stat-label {
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
+        /* Section Title */
+        .section-title {
+            font-size: 22px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 24px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        /* Referral Card */
+        .referral-card {
+            background: linear-gradient(135deg, var(--success), #059669);
+            color: white;
+            border-radius: var(--radius-lg);
+            padding: 32px;
+            margin-bottom: 32px;
+            box-shadow: var(--shadow-md);
+            position: relative;
+            overflow: hidden;
+        }
+
+        .referral-card::before {
+            content: '';
+            position: absolute;
+            top: -50px;
+            right: -50px;
+            width: 100px;
+            height: 100px;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 50%;
+        }
+
+        .referral-title {
+            font-size: 24px;
+            font-weight: 700;
+            margin-bottom: 12px;
+        }
+
+        .referral-subtitle {
+            font-size: 16px;
+            opacity: 0.9;
+            margin-bottom: 24px;
+        }
+
+        .referral-code-container {
+            background: rgba(255, 255, 255, 0.15);
+            border-radius: var(--radius);
+            padding: 16px;
+            margin-bottom: 24px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .referral-code {
+            font-size: 18px;
+            font-weight: 600;
+            font-family: 'Roboto', monospace;
+            letter-spacing: 2px;
+        }
+
+        .copy-btn {
+            background: rgba(255, 255, 255, 0.2);
+            border: none;
+            color: white;
+            padding: 8px 16px;
+            border-radius: var(--radius);
+            cursor: pointer;
+            font-size: 14px;
+            font-weight: 600;
+            transition: all 0.2s ease;
+        }
+
+        .copy-btn:hover {
+            background: rgba(255, 255, 255, 0.3);
+        }
+
+        .referral-actions {
+            display: flex;
+            gap: 12px;
+            flex-wrap: wrap;
+        }
+
+        .action-btn {
+            background: rgba(255, 255, 255, 0.2);
+            border: none;
+            color: white;
+            padding: 12px 20px;
+            border-radius: var(--radius);
+            cursor: pointer;
+            font-size: 14px;
+            font-weight: 600;
+            transition: all 0.2s ease;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .action-btn:hover {
+            background: rgba(255, 255, 255, 0.3);
+            transform: translateY(-1px);
+        }
+
+        /* Commission Tiers */
+        .commission-tiers {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            margin-bottom: 32px;
+            box-shadow: var(--shadow);
+        }
+
+        .tiers-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 20px;
+        }
+
+        .tier-card {
+            background: var(--bg-primary);
+            border: 2px solid var(--border);
+            border-radius: var(--radius);
+            padding: 20px;
+            text-align: center;
+            transition: all 0.2s ease;
+        }
+
+        .tier-card:hover {
+            border-color: var(--accent);
+            transform: translateY(-2px);
+        }
+
+        .tier-icon {
+            font-size: 32px;
+            margin-bottom: 16px;
+            color: var(--success);
+        }
+
+        .tier-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 8px;
+        }
+
+        .tier-commission {
+            font-size: 24px;
+            font-weight: 700;
+            color: var(--success);
+            margin-bottom: 8px;
+        }
+
+        .tier-description {
+            font-size: 14px;
+            color: var(--text-secondary);
+        }
+
+        /* Team List */
+        .team-section {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            box-shadow: var(--shadow);
+        }
+
+        .team-filters {
+            display: flex;
+            gap: 12px;
+            margin-bottom: 24px;
+            flex-wrap: wrap;
+        }
+
+        .filter-btn {
+            background: var(--bg-primary);
+            border: 1px solid var(--border);
+            color: var(--text-primary);
+            padding: 8px 16px;
+            border-radius: var(--radius);
+            cursor: pointer;
+            font-size: 14px;
+            font-weight: 500;
+            transition: all 0.2s ease;
+        }
+
+        .filter-btn.active {
+            background: var(--accent);
+            color: white;
+            border-color: var(--accent);
+        }
+
+        .filter-btn:hover {
+            border-color: var(--accent);
+        }
+
+        .team-member {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 20px;
+            border: 1px solid var(--border-light);
+            border-radius: var(--radius);
+            margin-bottom: 16px;
+            transition: all 0.2s ease;
+        }
+
+        .team-member:hover {
+            border-color: var(--accent);
+            transform: translateY(-1px);
+        }
+
+        .team-member:last-child {
+            margin-bottom: 0;
+        }
+
+        .member-left {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+        }
+
+        .member-avatar {
+            width: 48px;
+            height: 48px;
+            background: linear-gradient(135deg, var(--accent), var(--purple));
+            color: white;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 18px;
+            font-weight: 600;
+        }
+
+        .member-info h4 {
+            font-size: 16px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+        }
+
+        .member-info p {
+            font-size: 14px;
+            color: var(--text-secondary);
+        }
+
+        .member-right {
+            text-align: right;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+        }
+
+        .member-stats {
+            display: flex;
+            gap: 16px;
+            align-items: center;
+        }
+
+        .member-stat {
+            text-align: center;
+        }
+
+        .member-stat-value {
+            font-size: 14px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 2px;
+        }
+
+        .member-stat-label {
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        .member-level {
+            display: inline-block;
+            padding: 4px 8px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 600;
+            background: rgba(59, 130, 246, 0.1);
+            color: var(--accent);
+        }
+
+        /* Search Box */
+        .search-box {
+            position: relative;
+            margin-bottom: 24px;
+        }
+
+        .search-input {
+            width: 100%;
+            padding: 12px 16px 12px 48px;
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            font-size: 16px;
+            color: var(--text-primary);
+            background: var(--bg-card);
+            transition: all 0.2s ease;
+        }
+
+        .search-input:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+        }
+
+        .search-icon {
+            position: absolute;
+            left: 16px;
+            top: 50%;
+            transform: translateY(-50%);
+            color: var(--text-muted);
+            font-size: 16px;
+        }
+
+        /* Modal */
+        .modal {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.8);
+            z-index: 10000;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .modal.show {
+            display: flex;
+        }
+
+        .modal-content {
+            background: var(--bg-card);
+            border-radius: var(--radius-lg);
+            padding: 32px;
+            max-width: 500px;
+            width: 90%;
+            max-height: 90vh;
+            overflow-y: auto;
+            box-shadow: var(--shadow-lg);
+            animation: slideIn 0.3s ease;
+        }
+
+        .modal-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 24px;
+        }
+
+        .modal-title {
+            font-size: 24px;
+            font-weight: 700;
+            color: var(--text-primary);
+        }
+
+        .close-btn {
+            background: none;
+            border: none;
+            font-size: 24px;
+            color: var(--text-muted);
+            cursor: pointer;
+            padding: 8px;
+            border-radius: var(--radius);
+            transition: all 0.2s ease;
+        }
+
+        .close-btn:hover {
+            background: var(--border-light);
+            color: var(--text-primary);
+        }
+
+        .share-option {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            padding: 16px;
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            margin-bottom: 12px;
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .share-option:hover {
+            border-color: var(--accent);
+            background: var(--bg-primary);
+        }
+
+        .share-icon {
+            width: 48px;
+            height: 48px;
+            border-radius: var(--radius);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 20px;
+            color: white;
+        }
+
+        .whatsapp { background: #25D366; }
+        .telegram { background: #0088CC; }
+        .email { background: #EA4335; }
+        .copy { background: var(--accent); }
+
+        .share-info h4 {
+            font-size: 16px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+        }
+
+        .share-info p {
+            font-size: 14px;
+            color: var(--text-secondary);
+        }
+
+        /* Responsive */
+        @media (max-width: 1024px) {
+            .sidebar {
+                transform: translateX(-100%);
+                transition: transform 0.3s ease;
+            }
+            
+            .sidebar.open {
+                transform: translateX(0);
+            }
+            
+            .main-content {
+                margin-left: 0;
+                max-width: 100vw;
+                padding: 20px;
+            }
+            
+            .hamburger {
+                display: flex;
+            }
+
+            .tiers-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .team-member {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 16px;
+            }
+
+            .member-right {
+                width: 100%;
+                text-align: left;
+            }
+
+            .member-stats {
+                justify-content: space-between;
+                width: 100%;
+            }
+
+            .referral-actions {
+                justify-content: center;
+            }
+        }
+
+        /* Animations */
+        @keyframes slideIn {
+            from {
+                transform: translateY(-50px) scale(0.9);
+                opacity: 0;
+            }
+            to {
+                transform: translateY(0) scale(1);
+                opacity: 1;
+            }
+        }
+
+        @keyframes pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.7; }
+        }
+
+        .copied {
+            animation: pulse 0.6s ease-in-out;
+        }
+    </style>
+</head>
+
+<body>
+    <!-- Fixed Header -->
+    <header class="fixed-header">
+        <div class="header-left">
+            <button class="hamburger" onclick="toggleSidebar()">
+                <i class="fas fa-bars"></i>
+            </button>
+            <div class="header-title">FinverPro</div>
+        </div>
+    </header>
+
+    <!-- Sidebar -->
+    <nav class="sidebar" id="sidebar">
+        <div class="sidebar-content">
+            <div class="nav-section">
+                <div class="nav-section-title">Básico</div>
+                <a href="../dashboard/" class="nav-item">
+                    <i class="fas fa-home"></i>
+                    Início
+                </a>
+                <a href="#" class="nav-item active">
+                    <i class="fas fa-users"></i>
+                    Equipe
+                </a>
+                <a href="../perfil/" class="nav-item">
+                    <i class="fas fa-user-circle"></i>
+                    Perfil
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Investimentos</div>
+                <a href="../investimentos/" class="nav-item">
+                    <i class="fas fa-coins"></i>
+                    Produtos
+                </a>
+                <a href="../investimentos/" class="nav-item">
+                    <i class="fas fa-chart-line"></i>
+                    Meus Investimentos
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Diversão</div>
+                <a href="../roleta/" class="nav-item">
+                    <i class="fas fa-magic"></i>
+                    Roleta da Sorte
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Estatísticas</div>
+                <a href="../relatorios/" class="nav-item">
+                    <i class="fas fa-chart-bar"></i>
+                    Relatórios
+                </a>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Main Content -->
+    <main class="main-content">
+        <!-- Header -->
+        <div class="header">
+            <div class="header-left">
+                <h1>👥 Minha Equipe</h1>
+                <p>Construa sua rede e ganhe comissões por vida</p>
+            </div>
+        </div>
+
+        <!-- Stats Grid -->
+        <div class="stats-grid">
+            <div class="stat-card">
+                <div class="stat-icon">
+                    <i class="fas fa-users"></i>
+                </div>
+                <div class="stat-value">156</div>
+                <div class="stat-label">Total de Indicados</div>
+            </div>
+
+            <div class="stat-card">
+                <div class="stat-icon">
+                    <i class="fas fa-user-plus"></i>
+                </div>
+                <div class="stat-value">12</div>
+                <div class="stat-label">Novos Este Mês</div>
+            </div>
+
+            <div class="stat-card">
+                <div class="stat-icon">
+                    <i class="fas fa-coins"></i>
+                </div>
+                <div class="stat-value">R$ 4.852</div>
+                <div class="stat-label">Comissões Totais</div>
+            </div>
+
+            <div class="stat-card">
+                <div class="stat-icon">
+                    <i class="fas fa-chart-line"></i>
+                </div>
+                <div class="stat-value">R$ 382</div>
+                <div class="stat-label">Comissão Mensal</div>
+            </div>
+        </div>
+
+        <!-- Referral Card -->
+        <div class="referral-card">
+            <h2 class="referral-title">🚀 Programa de Indicação</h2>
+            <p class="referral-subtitle">
+                Compartilhe seu código e ganhe comissões vitalícias de todos os investimentos dos seus indicados!
+            </p>
+            
+            <div class="referral-code-container">
+                <div>
+                    <div style="font-size: 12px; opacity: 0.8; margin-bottom: 4px;">Seu código de indicação:</div>
+                    <div class="referral-code" id="referralCode">FINVER2024PRO</div>
+                </div>
+                <button class="copy-btn" onclick="copyReferralCode()">
+                    <i class="fas fa-copy"></i>
+                    Copiar
+                </button>
+            </div>
+            
+            <div class="referral-actions">
+                <button class="action-btn" onclick="shareViaWhatsApp()">
+                    <i class="fab fa-whatsapp"></i>
+                    WhatsApp
+                </button>
+                <button class="action-btn" onclick="shareViaTelegram()">
+                    <i class="fab fa-telegram"></i>
+                    Telegram
+                </button>
+                <button class="action-btn" onclick="openShareModal()">
+                    <i class="fas fa-share"></i>
+                    Mais Opções
+                </button>
+            </div>
+        </div>
+
+        <!-- Commission Tiers -->
+        <section class="commission-tiers">
+            <h2 class="section-title">
+                <i class="fas fa-trophy"></i>
+                Níveis de Comissão
+            </h2>
+            
+            <div class="tiers-grid">
+                <div class="tier-card">
+                    <div class="tier-icon">🥉</div>
+                    <h3 class="tier-title">Bronze</h3>
+                    <div class="tier-commission">3%</div>
+                    <p class="tier-description">1-10 indicados ativos</p>
+                </div>
+
+                <div class="tier-card">
+                    <div class="tier-icon">🥈</div>
+                    <h3 class="tier-title">Prata</h3>
+                    <div class="tier-commission">5%</div>
+                    <p class="tier-description">11-25 indicados ativos</p>
+                </div>
+
+                <div class="tier-card">
+                    <div class="tier-icon">🥇</div>
+                    <h3 class="tier-title">Ouro</h3>
+                    <div class="tier-commission">7%</div>
+                    <p class="tier-description">26-50 indicados ativos</p>
+                </div>
+
+                <div class="tier-card">
+                    <div class="tier-icon">💎</div>
+                    <h3 class="tier-title">Diamante</h3>
+                    <div class="tier-commission">10%</div>
+                    <p class="tier-description">51+ indicados ativos</p>
+                </div>
+            </div>
+        </section>
+
+        <!-- Team Section -->
+        <section class="team-section">
+            <h2 class="section-title">
+                <i class="fas fa-list"></i>
+                Minha Rede
+            </h2>
+            
+            <div class="search-box">
+                <i class="fas fa-search search-icon"></i>
+                <input type="text" class="search-input" placeholder="Buscar por nome ou telefone..." id="searchInput">
+            </div>
+            
+            <div class="team-filters">
+                <button class="filter-btn active" onclick="filterTeam('all')">Todos</button>
+                <button class="filter-btn" onclick="filterTeam('active')">Ativos</button>
+                <button class="filter-btn" onclick="filterTeam('new')">Novos</button>
+                <button class="filter-btn" onclick="filterTeam('inactive')">Inativos</button>
+            </div>
+            
+            <div class="team-list" id="teamList">
+                <div class="team-member" data-status="active">
+                    <div class="member-left">
+                        <div class="member-avatar">MJ</div>
+                        <div class="member-info">
+                            <h4>Maria João Silva</h4>
+                            <p>Indicado em 15/01/2024 • Último acesso: hoje</p>
+                        </div>
+                    </div>
+                    <div class="member-right">
+                        <div class="member-stats">
+                            <div class="member-stat">
+                                <div class="member-stat-value">R$ 5.280</div>
+                                <div class="member-stat-label">Investido</div>
+                            </div>
+                            <div class="member-stat">
+                                <div class="member-stat-value">R$ 158</div>
+                                <div class="member-stat-label">Comissão</div>
+                            </div>
+                        </div>
+                        <span class="member-level">Ativo</span>
+                    </div>
+                </div>
+
+                <div class="team-member" data-status="active">
+                    <div class="member-left">
+                        <div class="member-avatar">JS</div>
+                        <div class="member-info">
+                            <h4>João Santos</h4>
+                            <p>Indicado em 10/01/2024 • Último acesso: há 2 dias</p>
+                        </div>
+                    </div>
+                    <div class="member-right">
+                        <div class="member-stats">
+                            <div class="member-stat">
+                                <div class="member-stat-value">R$ 12.500</div>
+                                <div class="member-stat-label">Investido</div>
+                            </div>
+                            <div class="member-stat">
+                                <div class="member-stat-value">R$ 375</div>
+                                <div class="member-stat-label">Comissão</div>
+                            </div>
+                        </div>
+                        <span class="member-level">Ativo</span>
+                    </div>
+                </div>
+
+                <div class="team-member" data-status="new">
+                    <div class="member-left">
+                        <div class="member-avatar">AC</div>
+                        <div class="member-info">
+                            <h4>Ana Costa</h4>
+                            <p>Indicado em 28/01/2024 • Último acesso: ontem</p>
+                        </div>
+                    </div>
+                    <div class="member-right">
+                        <div class="member-stats">
+                            <div class="member-stat">
+                                <div class="member-stat-value">R$ 1.000</div>
+                                <div class="member-stat-label">Investido</div>
+                            </div>
+                            <div class="member-stat">
+                                <div class="member-stat-value">R$ 30</div>
+                                <div class="member-stat-label">Comissão</div>
+                            </div>
+                        </div>
+                        <span class="member-level" style="background: rgba(16, 185, 129, 0.1); color: var(--success);">Novo</span>
+                    </div>
+                </div>
+
+                <div class="team-member" data-status="active">
+                    <div class="member-left">
+                        <div class="member-avatar">RS</div>
+                        <div class="member-info">
+                            <h4>Roberto Silva</h4>
+                            <p>Indicado em 05/01/2024 • Último acesso: há 1 hora</p>
+                        </div>
+                    </div>
+                    <div class="member-right">
+                        <div class="member-stats">
+                            <div class="member-stat">
+                                <div class="member-stat-value">R$ 8.750</div>
+                                <div class="member-stat-label">Investido</div>
+                            </div>
+                            <div class="member-stat">
+                                <div class="member-stat-value">R$ 262</div>
+                                <div class="member-stat-label">Comissão</div>
+                            </div>
+                        </div>
+                        <span class="member-level">Ativo</span>
+                    </div>
+                </div>
+
+                <div class="team-member" data-status="inactive">
+                    <div class="member-left">
+                        <div class="member-avatar">CF</div>
+                        <div class="member-info">
+                            <h4>Carla Ferreira</h4>
+                            <p>Indicado em 20/12/2023 • Último acesso: há 15 dias</p>
+                        </div>
+                    </div>
+                    <div class="member-right">
+                        <div class="member-stats">
+                            <div class="member-stat">
+                                <div class="member-stat-value">R$ 2.500</div>
+                                <div class="member-stat-label">Investido</div>
+                            </div>
+                            <div class="member-stat">
+                                <div class="member-stat-value">R$ 75</div>
+                                <div class="member-stat-label">Comissão</div>
+                            </div>
+                        </div>
+                        <span class="member-level" style="background: rgba(220, 38, 38, 0.1); color: var(--danger);">Inativo</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Share Modal -->
+    <div class="modal" id="shareModal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 class="modal-title">Compartilhar Código</h3>
+                <button class="close-btn" onclick="closeShareModal()">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
+            
+            <div class="share-option" onclick="shareViaWhatsApp()">
+                <div class="share-icon whatsapp">
+                    <i class="fab fa-whatsapp"></i>
+                </div>
+                <div class="share-info">
+                    <h4>WhatsApp</h4>
+                    <p>Compartilhar via WhatsApp</p>
+                </div>
+            </div>
+
+            <div class="share-option" onclick="shareViaTelegram()">
+                <div class="share-icon telegram">
+                    <i class="fab fa-telegram"></i>
+                </div>
+                <div class="share-info">
+                    <h4>Telegram</h4>
+                    <p>Compartilhar via Telegram</p>
+                </div>
+            </div>
+
+            <div class="share-option" onclick="shareViaEmail()">
+                <div class="share-icon email">
+                    <i class="fas fa-envelope"></i>
+                </div>
+                <div class="share-info">
+                    <h4>E-mail</h4>
+                    <p>Enviar por e-mail</p>
+                </div>
+            </div>
+
+            <div class="share-option" onclick="copyReferralLink()">
+                <div class="share-icon copy">
+                    <i class="fas fa-link"></i>
+                </div>
+                <div class="share-info">
+                    <h4>Copiar Link</h4>
+                    <p>Copiar link de indicação</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        let currentFilter = 'all';
+
+        // Sidebar toggle for mobile
+        function toggleSidebar() {
+            const sidebar = document.getElementById('sidebar');
+            sidebar.classList.toggle('open');
+        }
+
+        // Copy referral code
+        function copyReferralCode() {
+            const code = document.getElementById('referralCode').textContent;
+            navigator.clipboard.writeText(code).then(() => {
+                const btn = event.target.closest('.copy-btn');
+                const originalContent = btn.innerHTML;
+                btn.innerHTML = '<i class="fas fa-check"></i> Copiado!';
+                btn.classList.add('copied');
+                
+                setTimeout(() => {
+                    btn.innerHTML = originalContent;
+                    btn.classList.remove('copied');
+                }, 2000);
+            });
+        }
+
+        // Share functions
+        function shareViaWhatsApp() {
+            const message = `🚀 Invista com inteligência no FinverPro! Use meu código FINVER2024PRO e comece a fazer seu dinheiro trabalhar para você. Acesse: https://finverpro.shop/ref/FINVER2024PRO`;
+            window.open(`https://api.whatsapp.com/send?text=${encodeURIComponent(message)}`, '_blank');
+        }
+
+        function shareViaTelegram() {
+            const message = `🚀 Invista com inteligência no FinverPro! Use meu código FINVER2024PRO e comece a fazer seu dinheiro trabalhar para você. Acesse: https://finverpro.shop/ref/FINVER2024PRO`;
+            window.open(`https://t.me/share/url?url=https://finverpro.shop/ref/FINVER2024PRO&text=${encodeURIComponent(message)}`, '_blank');
+        }
+
+        function shareViaEmail() {
+            const subject = 'Convite para investir no FinverPro';
+            const body = `Olá!\n\nGostaria de te convidar para conhecer o FinverPro, uma plataforma de investimentos com inteligência artificial.\n\nUse meu código de indicação: FINVER2024PRO\n\nAcesse: https://finverpro.shop/ref/FINVER2024PRO\n\nVamos investir juntos!`;
+            window.open(`mailto:?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`, '_blank');
+        }
+
+        function copyReferralLink() {
+            const link = 'https://finverpro.shop/ref/FINVER2024PRO';
+            navigator.clipboard.writeText(link).then(() => {
+                alert('Link copiado para a área de transferência!');
+                closeShareModal();
+            });
+        }
+
+        // Modal functions
+        function openShareModal() {
+            document.getElementById('shareModal').classList.add('show');
+        }
+
+        function closeShareModal() {
+            document.getElementById('shareModal').classList.remove('show');
+        }
+
+        // Filter team members
+        function filterTeam(filter) {
+            currentFilter = filter;
+            
+            // Update active filter button
+            document.querySelectorAll('.filter-btn').forEach(btn => {
+                btn.classList.remove('active');
+            });
+            event.target.classList.add('active');
+            
+            // Filter team members
+            const members = document.querySelectorAll('.team-member');
+            members.forEach(member => {
+                const status = member.getAttribute('data-status');
+                if (filter === 'all' || status === filter) {
+                    member.style.display = 'flex';
+                } else {
+                    member.style.display = 'none';
+                }
+            });
+        }
+
+        // Search team members
+        document.getElementById('searchInput').addEventListener('input', function() {
+            const searchTerm = this.value.toLowerCase();
+            const members = document.querySelectorAll('.team-member');
+            
+            members.forEach(member => {
+                const name = member.querySelector('.member-info h4').textContent.toLowerCase();
+                const info = member.querySelector('.member-info p').textContent.toLowerCase();
+                
+                if (name.includes(searchTerm) || info.includes(searchTerm)) {
+                    // Only show if it also matches current filter
+                    const status = member.getAttribute('data-status');
+                    if (currentFilter === 'all' || status === currentFilter) {
+                        member.style.display = 'flex';
+                    }
+                } else {
+                    member.style.display = 'none';
+                }
+            });
+        });
+
+        // Close modal when clicking outside
+        document.getElementById('shareModal').addEventListener('click', function(e) {
+            if (e.target === this) {
+                closeShareModal();
+            }
+        });
+
+        // Close sidebar when clicking outside on mobile
+        document.addEventListener('click', function(event) {
+            const sidebar = document.getElementById('sidebar');
+            const hamburger = document.querySelector('.hamburger');
+            
+            if (window.innerWidth <= 1024 && !sidebar.contains(event.target) && !hamburger.contains(event.target)) {
+                sidebar.classList.remove('open');
+            }
+        });
+
+        // Responsive handling
+        window.addEventListener('resize', function() {
+            const sidebar = document.getElementById('sidebar');
+            if (window.innerWidth > 1024) {
+                sidebar.classList.remove('open');
+            }
+        });
+
+        // Animate stats on page load
+        window.addEventListener('load', function() {
+            const statValues = document.querySelectorAll('.stat-value');
+            statValues.forEach((stat, index) => {
+                setTimeout(() => {
+                    stat.style.transform = 'scale(1.1)';
+                    setTimeout(() => {
+                        stat.style.transform = 'scale(1)';
+                    }, 200);
+                }, index * 100);
+            });
+        });
+    </script>
+</body>
+</html>

--- a/design/index.html
+++ b/design/index.html
@@ -1,0 +1,558 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FinverPro - Índice dos Designs</title>
+    
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Roboto:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    
+    <style>
+        :root {
+            --bg-primary: #F8FAFC;
+            --bg-secondary: #FFFFFF;
+            --bg-card: #FFFFFF;
+            
+            --primary: #0F172A;
+            --primary-light: #334155;
+            --accent: #3B82F6;
+            --success: #059669;
+            --warning: #D97706;
+            --danger: #DC2626;
+            --purple: #8B5CF6;
+            --pink: #EC4899;
+            --orange: #F97316;
+            
+            --text-primary: #0F172A;
+            --text-secondary: #64748B;
+            --text-muted: #94A3B8;
+            
+            --border: #E2E8F0;
+            --border-light: #F1F5F9;
+            
+            --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+            
+            --radius: 8px;
+            --radius-lg: 12px;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Inter', sans-serif;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            line-height: 1.5;
+            padding: 40px 20px;
+            min-height: 100vh;
+        }
+
+        .container {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        .header {
+            text-align: center;
+            margin-bottom: 60px;
+        }
+
+        .header h1 {
+            font-size: 48px;
+            font-weight: 800;
+            background: linear-gradient(135deg, var(--accent), var(--purple));
+            -webkit-background-clip: text;
+            -webkit-text-fill-color: transparent;
+            background-clip: text;
+            margin-bottom: 16px;
+            font-family: 'Roboto', sans-serif;
+        }
+
+        .header p {
+            font-size: 20px;
+            color: var(--text-secondary);
+            max-width: 600px;
+            margin: 0 auto 32px;
+        }
+
+        .badge {
+            display: inline-block;
+            background: linear-gradient(135deg, var(--success), #059669);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 14px;
+            font-weight: 600;
+        }
+
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+            gap: 24px;
+            margin-bottom: 60px;
+        }
+
+        .card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 32px;
+            box-shadow: var(--shadow);
+            transition: all 0.3s ease;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .card:hover {
+            transform: translateY(-8px);
+            box-shadow: var(--shadow-lg);
+            border-color: var(--accent);
+        }
+
+        .card::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 4px;
+            background: linear-gradient(90deg, var(--accent), var(--success));
+        }
+
+        .card-icon {
+            width: 64px;
+            height: 64px;
+            background: linear-gradient(135deg, var(--accent), var(--purple));
+            color: white;
+            border-radius: var(--radius-lg);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 24px;
+            margin-bottom: 20px;
+        }
+
+        .card h2 {
+            font-size: 24px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 12px;
+            font-family: 'Roboto', sans-serif;
+        }
+
+        .card p {
+            color: var(--text-secondary);
+            margin-bottom: 20px;
+            line-height: 1.6;
+        }
+
+        .card-features {
+            margin-bottom: 24px;
+        }
+
+        .feature {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+            font-size: 14px;
+            color: var(--text-secondary);
+        }
+
+        .feature i {
+            color: var(--success);
+            font-size: 12px;
+        }
+
+        .btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            background: linear-gradient(135deg, var(--accent), var(--purple));
+            color: white;
+            text-decoration: none;
+            padding: 12px 24px;
+            border-radius: var(--radius);
+            font-weight: 600;
+            font-size: 14px;
+            transition: all 0.2s ease;
+            width: 100%;
+            justify-content: center;
+        }
+
+        .btn:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-md);
+        }
+
+        .info-section {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 32px;
+            box-shadow: var(--shadow);
+            text-align: center;
+        }
+
+        .info-section h2 {
+            font-size: 28px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 16px;
+        }
+
+        .tech-stack {
+            display: flex;
+            justify-content: center;
+            gap: 16px;
+            flex-wrap: wrap;
+            margin-top: 24px;
+        }
+
+        .tech-item {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            background: var(--bg-primary);
+            padding: 8px 16px;
+            border-radius: var(--radius);
+            font-size: 14px;
+            font-weight: 500;
+            color: var(--text-primary);
+        }
+
+        .footer {
+            text-align: center;
+            margin-top: 60px;
+            padding: 24px;
+            color: var(--text-muted);
+            font-size: 14px;
+        }
+
+        /* Responsive */
+        @media (max-width: 768px) {
+            .header h1 {
+                font-size: 36px;
+            }
+
+            .header p {
+                font-size: 18px;
+            }
+
+            .grid {
+                grid-template-columns: 1fr;
+            }
+
+            .tech-stack {
+                justify-content: center;
+            }
+        }
+
+        /* Animations */
+        @keyframes fadeInUp {
+            from {
+                opacity: 0;
+                transform: translateY(30px);
+            }
+            to {
+                opacity: 1;
+                transform: translateY(0);
+            }
+        }
+
+        .card {
+            animation: fadeInUp 0.6s ease;
+        }
+
+        .card:nth-child(1) { animation-delay: 0.1s; }
+        .card:nth-child(2) { animation-delay: 0.2s; }
+        .card:nth-child(3) { animation-delay: 0.3s; }
+        .card:nth-child(4) { animation-delay: 0.4s; }
+        .card:nth-child(5) { animation-delay: 0.5s; }
+        .card:nth-child(6) { animation-delay: 0.6s; }
+    </style>
+</head>
+
+<body>
+    <div class="container">
+        <!-- Header -->
+        <div class="header">
+            <h1>🚀 FinverPro Designs</h1>
+            <p>Explore todos os designs criados para a plataforma FinverPro baseados no seu template. Cada página foi cuidadosamente desenvolvida com design moderno, responsivo e funcional.</p>
+            <div class="badge">✨ 6 Páginas Completas</div>
+        </div>
+
+        <!-- Pages Grid -->
+        <div class="grid">
+            <!-- Dashboard -->
+            <div class="card">
+                <div class="card-icon">
+                    <i class="fas fa-home"></i>
+                </div>
+                <h2>Dashboard</h2>
+                <p>Visão geral completa com estatísticas, gráficos interativos e ações rápidas para gestão financeira.</p>
+                <div class="card-features">
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Cards de estatísticas animados
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Gráficos de performance
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Últimas transações
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Menu lateral responsivo
+                    </div>
+                </div>
+                <a href="dashboard/" class="btn">
+                    <i class="fas fa-eye"></i>
+                    Visualizar Design
+                </a>
+            </div>
+
+            <!-- Roleta -->
+            <div class="card">
+                <div class="card-icon">
+                    <i class="fas fa-magic"></i>
+                </div>
+                <h2>Roleta da Sorte</h2>
+                <p>Jogo interativo com roleta animada, sistema de prêmios e histórico de vitórias para engajar usuários.</p>
+                <div class="card-features">
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Roleta totalmente animada
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Sistema de premiação
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Histórico de prêmios
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Animações fluidas
+                    </div>
+                </div>
+                <a href="roleta/" class="btn">
+                    <i class="fas fa-eye"></i>
+                    Visualizar Design
+                </a>
+            </div>
+
+            <!-- Investimentos -->
+            <div class="card">
+                <div class="card-icon">
+                    <i class="fas fa-coins"></i>
+                </div>
+                <h2>Investimentos</h2>
+                <p>Catálogo completo de produtos, simulador de rendimentos e gestão de investimentos ativos.</p>
+                <div class="card-features">
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Catálogo de produtos
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Modal de investimento
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Calculadora de rendimento
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Status em tempo real
+                    </div>
+                </div>
+                <a href="investimentos/" class="btn">
+                    <i class="fas fa-eye"></i>
+                    Visualizar Design
+                </a>
+            </div>
+
+            <!-- Equipe -->
+            <div class="card">
+                <div class="card-icon">
+                    <i class="fas fa-users"></i>
+                </div>
+                <h2>Minha Equipe</h2>
+                <p>Sistema completo de indicações com códigos de referência, níveis de comissão e compartilhamento social.</p>
+                <div class="card-features">
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Programa de indicações
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Códigos de referência
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Níveis de comissão
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Compartilhamento social
+                    </div>
+                </div>
+                <a href="equipe/" class="btn">
+                    <i class="fas fa-eye"></i>
+                    Visualizar Design
+                </a>
+            </div>
+
+            <!-- Perfil -->
+            <div class="card">
+                <div class="card-icon">
+                    <i class="fas fa-user-circle"></i>
+                </div>
+                <h2>Perfil</h2>
+                <p>Gestão completa de dados pessoais, configurações de segurança e preferências de notificação.</p>
+                <div class="card-features">
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Informações pessoais
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Configurações de segurança
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Sistema de notificações
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Upload de avatar
+                    </div>
+                </div>
+                <a href="perfil/" class="btn">
+                    <i class="fas fa-eye"></i>
+                    Visualizar Design
+                </a>
+            </div>
+
+            <!-- Relatórios -->
+            <div class="card">
+                <div class="card-icon">
+                    <i class="fas fa-chart-bar"></i>
+                </div>
+                <h2>Relatórios</h2>
+                <p>Dashboard avançado com gráficos interativos, análises de performance e exportação de relatórios.</p>
+                <div class="card-features">
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Gráficos interativos
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Métricas de performance
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Filtros de período
+                    </div>
+                    <div class="feature">
+                        <i class="fas fa-check"></i>
+                        Exportação de dados
+                    </div>
+                </div>
+                <a href="relatorios/" class="btn">
+                    <i class="fas fa-eye"></i>
+                    Visualizar Design
+                </a>
+            </div>
+        </div>
+
+        <!-- Info Section -->
+        <div class="info-section">
+            <h2>🛠️ Tecnologias Utilizadas</h2>
+            <p>Todos os designs foram desenvolvidos com tecnologias modernas e padrões de qualidade profissional, garantindo performance, acessibilidade e responsividade.</p>
+            
+            <div class="tech-stack">
+                <div class="tech-item">
+                    <i class="fab fa-html5" style="color: #E34F26;"></i>
+                    HTML5
+                </div>
+                <div class="tech-item">
+                    <i class="fab fa-css3-alt" style="color: #1572B6;"></i>
+                    CSS3
+                </div>
+                <div class="tech-item">
+                    <i class="fab fa-js-square" style="color: #F7DF1E;"></i>
+                    JavaScript ES6+
+                </div>
+                <div class="tech-item">
+                    <i class="fas fa-chart-line" style="color: #FF6384;"></i>
+                    Chart.js
+                </div>
+                <div class="tech-item">
+                    <i class="fab fa-font-awesome" style="color: #339AF0;"></i>
+                    Font Awesome
+                </div>
+                <div class="tech-item">
+                    <i class="fab fa-google" style="color: #4285F4;"></i>
+                    Google Fonts
+                </div>
+            </div>
+        </div>
+
+        <!-- Footer -->
+        <div class="footer">
+            <p>
+                💡 <strong>Dica:</strong> Todos os designs são totalmente responsivos e incluem versão mobile otimizada.<br>
+                📱 Teste em diferentes dispositivos para ver a adaptação automática do layout.
+            </p>
+        </div>
+    </div>
+
+    <script>
+        // Add some interactivity to the page
+        document.addEventListener('DOMContentLoaded', function() {
+            // Animate cards on scroll
+            const cards = document.querySelectorAll('.card');
+            
+            const observer = new IntersectionObserver((entries) => {
+                entries.forEach(entry => {
+                    if (entry.isIntersecting) {
+                        entry.target.style.animationPlayState = 'running';
+                    }
+                });
+            });
+
+            cards.forEach(card => {
+                observer.observe(card);
+            });
+
+            // Add hover effect to tech items
+            const techItems = document.querySelectorAll('.tech-item');
+            techItems.forEach(item => {
+                item.addEventListener('mouseenter', function() {
+                    this.style.transform = 'translateY(-4px)';
+                    this.style.boxShadow = '0 4px 12px rgba(0, 0, 0, 0.1)';
+                });
+                
+                item.addEventListener('mouseleave', function() {
+                    this.style.transform = 'translateY(0)';
+                    this.style.boxShadow = 'none';
+                });
+            });
+        });
+    </script>
+</body>
+</html>

--- a/design/investimentos/index.html
+++ b/design/investimentos/index.html
@@ -1,0 +1,1258 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FinverPro - Investimentos</title>
+    
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Roboto:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    
+    <style>
+        :root {
+            --bg-primary: #F8FAFC;
+            --bg-secondary: #FFFFFF;
+            --bg-sidebar: #1E293B;
+            --bg-card: #FFFFFF;
+            --bg-header: #FFFFFF;
+            
+            --primary: #0F172A;
+            --primary-light: #334155;
+            --accent: #3B82F6;
+            --success: #059669;
+            --warning: #D97706;
+            --danger: #DC2626;
+            --purple: #8B5CF6;
+            --pink: #EC4899;
+            --orange: #F97316;
+            
+            --text-primary: #0F172A;
+            --text-secondary: #64748B;
+            --text-muted: #94A3B8;
+            --text-white: #FFFFFF;
+            
+            --border: #E2E8F0;
+            --border-light: #F1F5F9;
+            
+            --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+            
+            --radius: 8px;
+            --radius-lg: 12px;
+        }
+
+        [data-theme="dark"] {
+            --bg-primary: #0F172A;
+            --bg-secondary: #1E293B;
+            --bg-sidebar: #0F172A;
+            --bg-card: #1E293B;
+            --bg-header: #1E293B;
+            
+            --primary: #F8FAFC;
+            --primary-light: #E2E8F0;
+            --accent: #3B82F6;
+            --success: #10B981;
+            --warning: #F59E0B;
+            --danger: #EF4444;
+            
+            --text-primary: #F8FAFC;
+            --text-secondary: #94A3B8;
+            --text-muted: #64748B;
+            --text-white: #FFFFFF;
+            
+            --border: #334155;
+            --border-light: #475569;
+            
+            --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3);
+            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.3);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Inter', sans-serif;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            line-height: 1.5;
+            display: flex;
+            min-height: 100vh;
+            transition: all 0.3s ease;
+        }
+
+        /* Fixed Header */
+        .fixed-header {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            background: var(--bg-header);
+            border-bottom: 1px solid var(--border);
+            padding: 16px 24px;
+            z-index: 1000;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            box-shadow: var(--shadow);
+        }
+
+        .header-left {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+        }
+
+        .hamburger {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            width: 40px;
+            height: 40px;
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            cursor: pointer;
+            box-shadow: var(--shadow);
+        }
+
+        .header-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: var(--text-primary);
+            font-family: 'Roboto', sans-serif;
+        }
+
+        /* Sidebar */
+        .sidebar {
+            width: 280px;
+            background: var(--bg-sidebar);
+            color: var(--text-white);
+            padding: 0;
+            position: fixed;
+            height: 100vh;
+            left: 0;
+            top: 72px;
+            z-index: 100;
+            display: flex;
+            flex-direction: column;
+            box-shadow: var(--shadow-lg);
+            transition: all 0.3s ease;
+        }
+
+        .sidebar-content {
+            flex: 1;
+            overflow-y: auto;
+            padding: 24px 0;
+        }
+
+        .nav-section {
+            margin-bottom: 32px;
+        }
+
+        .nav-section-title {
+            font-size: 12px;
+            font-weight: 600;
+            color: rgba(255, 255, 255, 0.5);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 16px;
+            padding: 0 24px;
+        }
+
+        .nav-item {
+            display: flex;
+            align-items: center;
+            padding: 12px 24px;
+            color: rgba(255, 255, 255, 0.8);
+            text-decoration: none;
+            transition: all 0.2s ease;
+            font-weight: 500;
+            border-right: 3px solid transparent;
+        }
+
+        .nav-item:hover {
+            background: rgba(255, 255, 255, 0.05);
+            color: var(--text-white);
+        }
+
+        .nav-item.active {
+            background: rgba(59, 130, 246, 0.1);
+            color: #3B82F6;
+            border-right-color: #3B82F6;
+        }
+
+        .nav-item i {
+            width: 20px;
+            margin-right: 12px;
+            font-size: 16px;
+        }
+
+        /* Main content */
+        .main-content {
+            flex: 1;
+            margin-left: 280px;
+            margin-top: 72px;
+            padding: 32px;
+            max-width: calc(100vw - 280px);
+        }
+
+        /* Header */
+        .header {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px 32px;
+            margin-bottom: 32px;
+            box-shadow: var(--shadow);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .header-left h1 {
+            font-size: 28px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+            font-family: 'Roboto', sans-serif;
+        }
+
+        .header-left p {
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
+        /* Balance Card */
+        .balance-card {
+            background: linear-gradient(135deg, var(--accent), var(--purple));
+            color: white;
+            border-radius: var(--radius-lg);
+            padding: 32px;
+            margin-bottom: 32px;
+            box-shadow: var(--shadow-md);
+            position: relative;
+            overflow: hidden;
+        }
+
+        .balance-card::before {
+            content: '';
+            position: absolute;
+            top: -50px;
+            right: -50px;
+            width: 100px;
+            height: 100px;
+            background: rgba(255, 255, 255, 0.1);
+            border-radius: 50%;
+        }
+
+        .balance-main {
+            font-size: 14px;
+            opacity: 0.9;
+            margin-bottom: 8px;
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .balance-amount {
+            font-size: 42px;
+            font-weight: 700;
+            margin-bottom: 16px;
+            font-family: 'Roboto', sans-serif;
+        }
+
+        .balance-details {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+        }
+
+        .balance-item {
+            text-align: center;
+        }
+
+        .balance-item-value {
+            font-size: 18px;
+            font-weight: 600;
+            margin-bottom: 4px;
+        }
+
+        .balance-item-label {
+            font-size: 12px;
+            opacity: 0.8;
+        }
+
+        /* Stats Grid */
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            margin-bottom: 32px;
+        }
+
+        .stat-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            box-shadow: var(--shadow);
+            transition: all 0.2s ease;
+            text-align: center;
+        }
+
+        .stat-card:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-md);
+        }
+
+        .stat-icon {
+            width: 48px;
+            height: 48px;
+            background: rgba(59, 130, 246, 0.1);
+            color: var(--accent);
+            border-radius: var(--radius);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0 auto 16px;
+            font-size: 20px;
+        }
+
+        .stat-value {
+            font-size: 24px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+        }
+
+        .stat-label {
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
+        /* Section Title */
+        .section-title {
+            font-size: 22px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 24px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        /* Products Grid */
+        .products-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+            gap: 24px;
+            margin-bottom: 32px;
+        }
+
+        .product-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            box-shadow: var(--shadow);
+            transition: all 0.2s ease;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .product-card:hover {
+            transform: translateY(-4px);
+            box-shadow: var(--shadow-lg);
+            border-color: var(--accent);
+        }
+
+        .product-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-bottom: 20px;
+        }
+
+        .product-icon {
+            width: 56px;
+            height: 56px;
+            background: linear-gradient(135deg, var(--accent), var(--purple));
+            color: white;
+            border-radius: var(--radius);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 24px;
+        }
+
+        .product-badge {
+            background: var(--success);
+            color: white;
+            padding: 6px 12px;
+            border-radius: 16px;
+            font-size: 12px;
+            font-weight: 600;
+        }
+
+        .product-title {
+            font-size: 20px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 8px;
+        }
+
+        .product-description {
+            color: var(--text-secondary);
+            font-size: 14px;
+            margin-bottom: 20px;
+            line-height: 1.6;
+        }
+
+        .product-stats {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 16px;
+            margin-bottom: 24px;
+        }
+
+        .product-stat {
+            text-align: center;
+            padding: 12px;
+            background: var(--bg-primary);
+            border-radius: var(--radius);
+        }
+
+        .product-stat-value {
+            font-size: 16px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+        }
+
+        .product-stat-label {
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        .product-progress {
+            margin-bottom: 20px;
+        }
+
+        .progress-label {
+            display: flex;
+            justify-content: space-between;
+            font-size: 12px;
+            color: var(--text-secondary);
+            margin-bottom: 8px;
+        }
+
+        .progress-bar {
+            width: 100%;
+            height: 8px;
+            background: var(--border-light);
+            border-radius: 4px;
+            overflow: hidden;
+        }
+
+        .progress-fill {
+            height: 100%;
+            background: linear-gradient(90deg, var(--success), var(--accent));
+            border-radius: 4px;
+            transition: width 0.3s ease;
+        }
+
+        .invest-btn {
+            width: 100%;
+            background: linear-gradient(135deg, var(--accent), var(--purple));
+            color: white;
+            border: none;
+            padding: 16px;
+            border-radius: var(--radius);
+            font-weight: 600;
+            cursor: pointer;
+            font-size: 16px;
+            transition: all 0.2s ease;
+        }
+
+        .invest-btn:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-md);
+        }
+
+        /* My Investments */
+        .my-investments {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            box-shadow: var(--shadow);
+        }
+
+        .investment-item {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 20px;
+            border: 1px solid var(--border-light);
+            border-radius: var(--radius);
+            margin-bottom: 16px;
+            transition: all 0.2s ease;
+        }
+
+        .investment-item:hover {
+            border-color: var(--accent);
+            transform: translateY(-2px);
+        }
+
+        .investment-item:last-child {
+            margin-bottom: 0;
+        }
+
+        .investment-left {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+        }
+
+        .investment-icon {
+            width: 48px;
+            height: 48px;
+            background: linear-gradient(135deg, var(--accent), var(--purple));
+            color: white;
+            border-radius: var(--radius);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 18px;
+        }
+
+        .investment-details h4 {
+            font-size: 16px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+        }
+
+        .investment-details p {
+            font-size: 14px;
+            color: var(--text-secondary);
+        }
+
+        .investment-right {
+            text-align: right;
+        }
+
+        .investment-value {
+            font-size: 18px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+        }
+
+        .investment-status {
+            display: inline-block;
+            padding: 4px 8px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 600;
+        }
+
+        .status-active {
+            background: rgba(5, 150, 105, 0.1);
+            color: var(--success);
+        }
+
+        .status-completed {
+            background: rgba(59, 130, 246, 0.1);
+            color: var(--accent);
+        }
+
+        /* Modal */
+        .modal {
+            display: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background: rgba(0, 0, 0, 0.8);
+            z-index: 10000;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .modal.show {
+            display: flex;
+        }
+
+        .modal-content {
+            background: var(--bg-card);
+            border-radius: var(--radius-lg);
+            padding: 32px;
+            max-width: 500px;
+            width: 90%;
+            max-height: 90vh;
+            overflow-y: auto;
+            box-shadow: var(--shadow-lg);
+            animation: slideIn 0.3s ease;
+        }
+
+        .modal-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 24px;
+        }
+
+        .modal-title {
+            font-size: 24px;
+            font-weight: 700;
+            color: var(--text-primary);
+        }
+
+        .close-btn {
+            background: none;
+            border: none;
+            font-size: 24px;
+            color: var(--text-muted);
+            cursor: pointer;
+            padding: 8px;
+            border-radius: var(--radius);
+            transition: all 0.2s ease;
+        }
+
+        .close-btn:hover {
+            background: var(--border-light);
+            color: var(--text-primary);
+        }
+
+        .form-group {
+            margin-bottom: 20px;
+        }
+
+        .form-label {
+            display: block;
+            font-size: 14px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 8px;
+        }
+
+        .form-input {
+            width: 100%;
+            padding: 12px 16px;
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            font-size: 16px;
+            color: var(--text-primary);
+            background: var(--bg-card);
+            transition: all 0.2s ease;
+        }
+
+        .form-input:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+        }
+
+        .form-info {
+            font-size: 12px;
+            color: var(--text-secondary);
+            margin-top: 4px;
+        }
+
+        .modal-footer {
+            display: flex;
+            gap: 12px;
+            justify-content: flex-end;
+            margin-top: 24px;
+        }
+
+        .btn {
+            padding: 12px 24px;
+            border-radius: var(--radius);
+            font-weight: 600;
+            cursor: pointer;
+            font-size: 14px;
+            transition: all 0.2s ease;
+            border: none;
+        }
+
+        .btn-secondary {
+            background: var(--border-light);
+            color: var(--text-primary);
+        }
+
+        .btn-secondary:hover {
+            background: var(--border);
+        }
+
+        .btn-primary {
+            background: linear-gradient(135deg, var(--accent), var(--purple));
+            color: white;
+        }
+
+        .btn-primary:hover {
+            transform: translateY(-1px);
+            box-shadow: var(--shadow-md);
+        }
+
+        /* Responsive */
+        @media (max-width: 1024px) {
+            .sidebar {
+                transform: translateX(-100%);
+                transition: transform 0.3s ease;
+            }
+            
+            .sidebar.open {
+                transform: translateX(0);
+            }
+            
+            .main-content {
+                margin-left: 0;
+                max-width: 100vw;
+                padding: 20px;
+            }
+            
+            .hamburger {
+                display: flex;
+            }
+
+            .products-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .investment-item {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 16px;
+            }
+
+            .investment-right {
+                text-align: left;
+                width: 100%;
+            }
+        }
+
+        /* Animations */
+        @keyframes slideIn {
+            from {
+                transform: translateY(-50px) scale(0.9);
+                opacity: 0;
+            }
+            to {
+                transform: translateY(0) scale(1);
+                opacity: 1;
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <!-- Fixed Header -->
+    <header class="fixed-header">
+        <div class="header-left">
+            <button class="hamburger" onclick="toggleSidebar()">
+                <i class="fas fa-bars"></i>
+            </button>
+            <div class="header-title">FinverPro</div>
+        </div>
+    </header>
+
+    <!-- Sidebar -->
+    <nav class="sidebar" id="sidebar">
+        <div class="sidebar-content">
+            <div class="nav-section">
+                <div class="nav-section-title">Básico</div>
+                <a href="../dashboard/" class="nav-item">
+                    <i class="fas fa-home"></i>
+                    Início
+                </a>
+                <a href="../equipe/" class="nav-item">
+                    <i class="fas fa-users"></i>
+                    Equipe
+                </a>
+                <a href="../perfil/" class="nav-item">
+                    <i class="fas fa-user-circle"></i>
+                    Perfil
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Investimentos</div>
+                <a href="#" class="nav-item active">
+                    <i class="fas fa-coins"></i>
+                    Produtos
+                </a>
+                <a href="#" class="nav-item">
+                    <i class="fas fa-chart-line"></i>
+                    Meus Investimentos
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Diversão</div>
+                <a href="../roleta/" class="nav-item">
+                    <i class="fas fa-magic"></i>
+                    Roleta da Sorte
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Estatísticas</div>
+                <a href="../relatorios/" class="nav-item">
+                    <i class="fas fa-chart-bar"></i>
+                    Relatórios
+                </a>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Main Content -->
+    <main class="main-content">
+        <!-- Header -->
+        <div class="header">
+            <div class="header-left">
+                <h1>💰 Investimentos</h1>
+                <p>Faça seu dinheiro trabalhar para você</p>
+            </div>
+        </div>
+
+        <!-- Balance Card -->
+        <div class="balance-card">
+            <div class="balance-main">Saldo Disponível</div>
+            <div class="balance-amount">R$ 12.547,89</div>
+            <div class="balance-details">
+                <div class="balance-item">
+                    <div class="balance-item-value">R$ 10.547,89</div>
+                    <div class="balance-item-label">Saldo Principal</div>
+                </div>
+                <div class="balance-item">
+                    <div class="balance-item-value">R$ 2.000,00</div>
+                    <div class="balance-item-label">Saldo Bônus</div>
+                </div>
+                <div class="balance-item">
+                    <div class="balance-item-value">R$ 45.280,00</div>
+                    <div class="balance-item-label">Total Investido</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Stats Grid -->
+        <div class="stats-grid">
+            <div class="stat-card">
+                <div class="stat-icon">
+                    <i class="fas fa-chart-line"></i>
+                </div>
+                <div class="stat-value">8</div>
+                <div class="stat-label">Investimentos Ativos</div>
+            </div>
+
+            <div class="stat-card">
+                <div class="stat-icon">
+                    <i class="fas fa-coins"></i>
+                </div>
+                <div class="stat-value">R$ 3.842</div>
+                <div class="stat-label">Rendimento Mensal</div>
+            </div>
+
+            <div class="stat-card">
+                <div class="stat-icon">
+                    <i class="fas fa-trophy"></i>
+                </div>
+                <div class="stat-value">15.2%</div>
+                <div class="stat-label">Rentabilidade</div>
+            </div>
+
+            <div class="stat-card">
+                <div class="stat-icon">
+                    <i class="fas fa-calendar"></i>
+                </div>
+                <div class="stat-value">127</div>
+                <div class="stat-label">Dias Médios</div>
+            </div>
+        </div>
+
+        <!-- Products Section -->
+        <section>
+            <h2 class="section-title">
+                <i class="fas fa-gem"></i>
+                Produtos de Investimento
+            </h2>
+            
+            <div class="products-grid">
+                <div class="product-card">
+                    <div class="product-header">
+                        <div class="product-icon">
+                            <i class="fas fa-chart-line"></i>
+                        </div>
+                        <div class="product-badge">15.2% a.a.</div>
+                    </div>
+                    
+                    <h3 class="product-title">Renda Fixa Premium</h3>
+                    <p class="product-description">
+                        Investimento conservador com retorno garantido. Ideal para quem busca segurança e previsibilidade nos ganhos.
+                    </p>
+                    
+                    <div class="product-stats">
+                        <div class="product-stat">
+                            <div class="product-stat-value">R$ 1.000</div>
+                            <div class="product-stat-label">Mínimo</div>
+                        </div>
+                        <div class="product-stat">
+                            <div class="product-stat-value">180 dias</div>
+                            <div class="product-stat-label">Duração</div>
+                        </div>
+                    </div>
+                    
+                    <div class="product-progress">
+                        <div class="progress-label">
+                            <span>Vendidos</span>
+                            <span>247/500</span>
+                        </div>
+                        <div class="progress-bar">
+                            <div class="progress-fill" style="width: 49.4%"></div>
+                        </div>
+                    </div>
+                    
+                    <button class="invest-btn" onclick="openInvestModal('Renda Fixa Premium', 1000, 50000)">
+                        <i class="fas fa-plus-circle"></i>
+                        Investir Agora
+                    </button>
+                </div>
+
+                <div class="product-card">
+                    <div class="product-header">
+                        <div class="product-icon">
+                            <i class="fas fa-trending-up"></i>
+                        </div>
+                        <div class="product-badge">18.7% a.a.</div>
+                    </div>
+                    
+                    <h3 class="product-title">Multi Plus</h3>
+                    <p class="product-description">
+                        Carteira diversificada com foco em crescimento. Combina segurança com potencial de alto retorno.
+                    </p>
+                    
+                    <div class="product-stats">
+                        <div class="product-stat">
+                            <div class="product-stat-value">R$ 5.000</div>
+                            <div class="product-stat-label">Mínimo</div>
+                        </div>
+                        <div class="product-stat">
+                            <div class="product-stat-value">365 dias</div>
+                            <div class="product-stat-label">Duração</div>
+                        </div>
+                    </div>
+                    
+                    <div class="product-progress">
+                        <div class="progress-label">
+                            <span>Vendidos</span>
+                            <span>89/200</span>
+                        </div>
+                        <div class="progress-bar">
+                            <div class="progress-fill" style="width: 44.5%"></div>
+                        </div>
+                    </div>
+                    
+                    <button class="invest-btn" onclick="openInvestModal('Multi Plus', 5000, 100000)">
+                        <i class="fas fa-plus-circle"></i>
+                        Investir Agora
+                    </button>
+                </div>
+
+                <div class="product-card">
+                    <div class="product-header">
+                        <div class="product-icon">
+                            <i class="fas fa-gem"></i>
+                        </div>
+                        <div class="product-badge">22.1% a.a.</div>
+                    </div>
+                    
+                    <h3 class="product-title">Elite Invest</h3>
+                    <p class="product-description">
+                        Para investidores experientes. Alto potencial de retorno com estratégias avançadas de mercado.
+                    </p>
+                    
+                    <div class="product-stats">
+                        <div class="product-stat">
+                            <div class="product-stat-value">R$ 10.000</div>
+                            <div class="product-stat-label">Mínimo</div>
+                        </div>
+                        <div class="product-stat">
+                            <div class="product-stat-value">540 dias</div>
+                            <div class="product-stat-label">Duração</div>
+                        </div>
+                    </div>
+                    
+                    <div class="product-progress">
+                        <div class="progress-label">
+                            <span>Vendidos</span>
+                            <span>23/100</span>
+                        </div>
+                        <div class="progress-bar">
+                            <div class="progress-fill" style="width: 23%"></div>
+                        </div>
+                    </div>
+                    
+                    <button class="invest-btn" onclick="openInvestModal('Elite Invest', 10000, 500000)">
+                        <i class="fas fa-plus-circle"></i>
+                        Investir Agora
+                    </button>
+                </div>
+            </div>
+        </section>
+
+        <!-- My Investments Section -->
+        <section>
+            <h2 class="section-title">
+                <i class="fas fa-wallet"></i>
+                Meus Investimentos
+            </h2>
+            
+            <div class="my-investments">
+                <div class="investment-item">
+                    <div class="investment-left">
+                        <div class="investment-icon">
+                            <i class="fas fa-chart-line"></i>
+                        </div>
+                        <div class="investment-details">
+                            <h4>Renda Fixa Premium</h4>
+                            <p>Investido em 15/01/2024 • 45 dias restantes</p>
+                        </div>
+                    </div>
+                    <div class="investment-right">
+                        <div class="investment-value">R$ 5.152,00</div>
+                        <span class="investment-status status-active">Ativo</span>
+                    </div>
+                </div>
+
+                <div class="investment-item">
+                    <div class="investment-left">
+                        <div class="investment-icon">
+                            <i class="fas fa-trending-up"></i>
+                        </div>
+                        <div class="investment-details">
+                            <h4>Multi Plus</h4>
+                            <p>Investido em 10/12/2023 • 182 dias restantes</p>
+                        </div>
+                    </div>
+                    <div class="investment-right">
+                        <div class="investment-value">R$ 12.935,00</div>
+                        <span class="investment-status status-active">Ativo</span>
+                    </div>
+                </div>
+
+                <div class="investment-item">
+                    <div class="investment-left">
+                        <div class="investment-icon">
+                            <i class="fas fa-gem"></i>
+                        </div>
+                        <div class="investment-details">
+                            <h4>Elite Invest</h4>
+                            <p>Investido em 01/11/2023 • 298 dias restantes</p>
+                        </div>
+                    </div>
+                    <div class="investment-right">
+                        <div class="investment-value">R$ 22.210,00</div>
+                        <span class="investment-status status-active">Ativo</span>
+                    </div>
+                </div>
+
+                <div class="investment-item">
+                    <div class="investment-left">
+                        <div class="investment-icon">
+                            <i class="fas fa-check-circle"></i>
+                        </div>
+                        <div class="investment-details">
+                            <h4>Renda Fixa Premium</h4>
+                            <p>Finalizado em 08/01/2024 • Rendimento: +15.2%</p>
+                        </div>
+                    </div>
+                    <div class="investment-right">
+                        <div class="investment-value">R$ 2.304,00</div>
+                        <span class="investment-status status-completed">Concluído</span>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <!-- Investment Modal -->
+    <div class="modal" id="investModal">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h3 class="modal-title" id="modalTitle">Realizar Investimento</h3>
+                <button class="close-btn" onclick="closeInvestModal()">
+                    <i class="fas fa-times"></i>
+                </button>
+            </div>
+            
+            <form id="investForm">
+                <div class="form-group">
+                    <label class="form-label">Produto</label>
+                    <input type="text" class="form-input" id="productName" readonly>
+                </div>
+                
+                <div class="form-group">
+                    <label class="form-label">Valor do Investimento</label>
+                    <input type="number" class="form-input" id="investAmount" 
+                           placeholder="Digite o valor..." step="0.01" min="0">
+                    <div class="form-info">
+                        Valor mínimo: R$ <span id="minAmount">0</span> | 
+                        Saldo disponível: R$ 12.547,89
+                    </div>
+                </div>
+                
+                <div class="form-group">
+                    <label class="form-label">Resumo do Investimento</label>
+                    <div style="background: var(--bg-primary); padding: 16px; border-radius: var(--radius); border: 1px solid var(--border);">
+                        <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
+                            <span>Valor investido:</span>
+                            <span id="summaryAmount">R$ 0,00</span>
+                        </div>
+                        <div style="display: flex; justify-content: space-between; margin-bottom: 8px;">
+                            <span>Rendimento estimado:</span>
+                            <span id="summaryReturn">R$ 0,00</span>
+                        </div>
+                        <div style="display: flex; justify-content: space-between; font-weight: 600;">
+                            <span>Total estimado:</span>
+                            <span id="summaryTotal">R$ 0,00</span>
+                        </div>
+                    </div>
+                </div>
+            </form>
+            
+            <div class="modal-footer">
+                <button class="btn btn-secondary" onclick="closeInvestModal()">
+                    Cancelar
+                </button>
+                <button class="btn btn-primary" onclick="confirmInvestment()">
+                    <i class="fas fa-check"></i>
+                    Confirmar Investimento
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        let currentProduct = {};
+
+        // Sidebar toggle for mobile
+        function toggleSidebar() {
+            const sidebar = document.getElementById('sidebar');
+            sidebar.classList.toggle('open');
+        }
+
+        // Open investment modal
+        function openInvestModal(productName, minAmount, maxAmount) {
+            currentProduct = { name: productName, min: minAmount, max: maxAmount };
+            
+            document.getElementById('modalTitle').textContent = `Investir em ${productName}`;
+            document.getElementById('productName').value = productName;
+            document.getElementById('investAmount').min = minAmount;
+            document.getElementById('investAmount').max = maxAmount;
+            document.getElementById('minAmount').textContent = minAmount.toLocaleString('pt-BR');
+            
+            // Set default amount to minimum
+            document.getElementById('investAmount').value = minAmount;
+            updateSummary();
+            
+            document.getElementById('investModal').classList.add('show');
+        }
+
+        // Close investment modal
+        function closeInvestModal() {
+            document.getElementById('investModal').classList.remove('show');
+            document.getElementById('investForm').reset();
+        }
+
+        // Update investment summary
+        function updateSummary() {
+            const amount = parseFloat(document.getElementById('investAmount').value) || 0;
+            const returnRate = getReturnRate(currentProduct.name);
+            const returnAmount = amount * (returnRate / 100);
+            const total = amount + returnAmount;
+            
+            document.getElementById('summaryAmount').textContent = `R$ ${amount.toLocaleString('pt-BR', {minimumFractionDigits: 2})}`;
+            document.getElementById('summaryReturn').textContent = `R$ ${returnAmount.toLocaleString('pt-BR', {minimumFractionDigits: 2})}`;
+            document.getElementById('summaryTotal').textContent = `R$ ${total.toLocaleString('pt-BR', {minimumFractionDigits: 2})}`;
+        }
+
+        // Get return rate by product name
+        function getReturnRate(productName) {
+            const rates = {
+                'Renda Fixa Premium': 15.2,
+                'Multi Plus': 18.7,
+                'Elite Invest': 22.1
+            };
+            return rates[productName] || 0;
+        }
+
+        // Confirm investment
+        function confirmInvestment() {
+            const amount = parseFloat(document.getElementById('investAmount').value);
+            
+            if (!amount || amount < currentProduct.min) {
+                alert(`Valor mínimo é R$ ${currentProduct.min.toLocaleString('pt-BR')}`);
+                return;
+            }
+            
+            if (amount > 12547.89) {
+                alert('Saldo insuficiente');
+                return;
+            }
+            
+            // Simulate API call
+            const btn = document.querySelector('.btn-primary');
+            btn.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Processando...';
+            btn.disabled = true;
+            
+            setTimeout(() => {
+                alert(`Investimento de R$ ${amount.toLocaleString('pt-BR', {minimumFractionDigits: 2})} realizado com sucesso!`);
+                closeInvestModal();
+                btn.innerHTML = '<i class="fas fa-check"></i> Confirmar Investimento';
+                btn.disabled = false;
+                
+                // Simulate page refresh
+                setTimeout(() => {
+                    location.reload();
+                }, 1000);
+            }, 2000);
+        }
+
+        // Event listeners
+        document.getElementById('investAmount').addEventListener('input', updateSummary);
+
+        // Close modal when clicking outside
+        document.getElementById('investModal').addEventListener('click', function(e) {
+            if (e.target === this) {
+                closeInvestModal();
+            }
+        });
+
+        // Close sidebar when clicking outside on mobile
+        document.addEventListener('click', function(event) {
+            const sidebar = document.getElementById('sidebar');
+            const hamburger = document.querySelector('.hamburger');
+            
+            if (window.innerWidth <= 1024 && !sidebar.contains(event.target) && !hamburger.contains(event.target)) {
+                sidebar.classList.remove('open');
+            }
+        });
+
+        // Responsive handling
+        window.addEventListener('resize', function() {
+            const sidebar = document.getElementById('sidebar');
+            if (window.innerWidth > 1024) {
+                sidebar.classList.remove('open');
+            }
+        });
+    </script>
+</body>
+</html>

--- a/design/perfil/index.html
+++ b/design/perfil/index.html
@@ -1,0 +1,1248 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FinverPro - Perfil</title>
+    
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Roboto:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    
+    <style>
+        :root {
+            --bg-primary: #F8FAFC;
+            --bg-secondary: #FFFFFF;
+            --bg-sidebar: #1E293B;
+            --bg-card: #FFFFFF;
+            --bg-header: #FFFFFF;
+            
+            --primary: #0F172A;
+            --primary-light: #334155;
+            --accent: #3B82F6;
+            --success: #059669;
+            --warning: #D97706;
+            --danger: #DC2626;
+            --purple: #8B5CF6;
+            --pink: #EC4899;
+            --orange: #F97316;
+            
+            --text-primary: #0F172A;
+            --text-secondary: #64748B;
+            --text-muted: #94A3B8;
+            --text-white: #FFFFFF;
+            
+            --border: #E2E8F0;
+            --border-light: #F1F5F9;
+            
+            --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+            
+            --radius: 8px;
+            --radius-lg: 12px;
+        }
+
+        [data-theme="dark"] {
+            --bg-primary: #0F172A;
+            --bg-secondary: #1E293B;
+            --bg-sidebar: #0F172A;
+            --bg-card: #1E293B;
+            --bg-header: #1E293B;
+            
+            --primary: #F8FAFC;
+            --primary-light: #E2E8F0;
+            --accent: #3B82F6;
+            --success: #10B981;
+            --warning: #F59E0B;
+            --danger: #EF4444;
+            
+            --text-primary: #F8FAFC;
+            --text-secondary: #94A3B8;
+            --text-muted: #64748B;
+            --text-white: #FFFFFF;
+            
+            --border: #334155;
+            --border-light: #475569;
+            
+            --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3);
+            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.3);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Inter', sans-serif;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            line-height: 1.5;
+            display: flex;
+            min-height: 100vh;
+            transition: all 0.3s ease;
+        }
+
+        /* Fixed Header */
+        .fixed-header {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            background: var(--bg-header);
+            border-bottom: 1px solid var(--border);
+            padding: 16px 24px;
+            z-index: 1000;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            box-shadow: var(--shadow);
+        }
+
+        .header-left {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+        }
+
+        .hamburger {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            width: 40px;
+            height: 40px;
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            cursor: pointer;
+            box-shadow: var(--shadow);
+        }
+
+        .header-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: var(--text-primary);
+            font-family: 'Roboto', sans-serif;
+        }
+
+        /* Sidebar */
+        .sidebar {
+            width: 280px;
+            background: var(--bg-sidebar);
+            color: var(--text-white);
+            padding: 0;
+            position: fixed;
+            height: 100vh;
+            left: 0;
+            top: 72px;
+            z-index: 100;
+            display: flex;
+            flex-direction: column;
+            box-shadow: var(--shadow-lg);
+            transition: all 0.3s ease;
+        }
+
+        .sidebar-content {
+            flex: 1;
+            overflow-y: auto;
+            padding: 24px 0;
+        }
+
+        .nav-section {
+            margin-bottom: 32px;
+        }
+
+        .nav-section-title {
+            font-size: 12px;
+            font-weight: 600;
+            color: rgba(255, 255, 255, 0.5);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 16px;
+            padding: 0 24px;
+        }
+
+        .nav-item {
+            display: flex;
+            align-items: center;
+            padding: 12px 24px;
+            color: rgba(255, 255, 255, 0.8);
+            text-decoration: none;
+            transition: all 0.2s ease;
+            font-weight: 500;
+            border-right: 3px solid transparent;
+        }
+
+        .nav-item:hover {
+            background: rgba(255, 255, 255, 0.05);
+            color: var(--text-white);
+        }
+
+        .nav-item.active {
+            background: rgba(59, 130, 246, 0.1);
+            color: #3B82F6;
+            border-right-color: #3B82F6;
+        }
+
+        .nav-item i {
+            width: 20px;
+            margin-right: 12px;
+            font-size: 16px;
+        }
+
+        /* Main content */
+        .main-content {
+            flex: 1;
+            margin-left: 280px;
+            margin-top: 72px;
+            padding: 32px;
+            max-width: calc(100vw - 280px);
+        }
+
+        /* Header */
+        .header {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px 32px;
+            margin-bottom: 32px;
+            box-shadow: var(--shadow);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .header-left h1 {
+            font-size: 28px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+            font-family: 'Roboto', sans-serif;
+        }
+
+        .header-left p {
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
+        /* Profile Grid */
+        .profile-grid {
+            display: grid;
+            grid-template-columns: 1fr 2fr;
+            gap: 32px;
+            margin-bottom: 32px;
+        }
+
+        /* Profile Card */
+        .profile-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 32px;
+            box-shadow: var(--shadow);
+            text-align: center;
+            height: fit-content;
+        }
+
+        .profile-avatar {
+            width: 120px;
+            height: 120px;
+            background: linear-gradient(135deg, var(--accent), var(--purple));
+            color: white;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0 auto 24px;
+            font-size: 48px;
+            font-weight: 600;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .profile-avatar img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            border-radius: 50%;
+        }
+
+        .avatar-upload {
+            position: absolute;
+            bottom: 8px;
+            right: 8px;
+            width: 32px;
+            height: 32px;
+            background: var(--accent);
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            color: white;
+            font-size: 14px;
+            border: 2px solid white;
+            transition: all 0.2s ease;
+        }
+
+        .avatar-upload:hover {
+            background: var(--purple);
+            transform: scale(1.1);
+        }
+
+        .profile-name {
+            font-size: 24px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 8px;
+        }
+
+        .profile-level {
+            display: inline-block;
+            background: linear-gradient(135deg, var(--success), #059669);
+            color: white;
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 24px;
+        }
+
+        .profile-stats {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 16px;
+            margin-bottom: 24px;
+        }
+
+        .profile-stat {
+            text-align: center;
+            padding: 16px;
+            background: var(--bg-primary);
+            border-radius: var(--radius);
+        }
+
+        .profile-stat-value {
+            font-size: 18px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+        }
+
+        .profile-stat-label {
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        /* Settings Tabs */
+        .settings-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            box-shadow: var(--shadow);
+            overflow: hidden;
+        }
+
+        .settings-tabs {
+            display: flex;
+            background: var(--bg-primary);
+            border-bottom: 1px solid var(--border);
+        }
+
+        .tab-btn {
+            flex: 1;
+            background: none;
+            border: none;
+            padding: 16px 24px;
+            color: var(--text-secondary);
+            font-weight: 500;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            position: relative;
+        }
+
+        .tab-btn.active {
+            color: var(--accent);
+            background: var(--bg-card);
+        }
+
+        .tab-btn.active::after {
+            content: '';
+            position: absolute;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            height: 2px;
+            background: var(--accent);
+        }
+
+        .tab-content {
+            padding: 32px;
+            display: none;
+        }
+
+        .tab-content.active {
+            display: block;
+        }
+
+        /* Form Styles */
+        .form-group {
+            margin-bottom: 24px;
+        }
+
+        .form-label {
+            display: block;
+            font-size: 14px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 8px;
+        }
+
+        .form-input {
+            width: 100%;
+            padding: 12px 16px;
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            font-size: 16px;
+            color: var(--text-primary);
+            background: var(--bg-card);
+            transition: all 0.2s ease;
+        }
+
+        .form-input:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+        }
+
+        .form-input:disabled {
+            background: var(--bg-primary);
+            color: var(--text-muted);
+            cursor: not-allowed;
+        }
+
+        .form-row {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 16px;
+        }
+
+        .form-info {
+            font-size: 12px;
+            color: var(--text-secondary);
+            margin-top: 4px;
+        }
+
+        /* Buttons */
+        .btn {
+            padding: 12px 24px;
+            border-radius: var(--radius);
+            font-weight: 600;
+            cursor: pointer;
+            font-size: 14px;
+            transition: all 0.2s ease;
+            border: none;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .btn-primary {
+            background: linear-gradient(135deg, var(--accent), var(--purple));
+            color: white;
+        }
+
+        .btn-primary:hover {
+            transform: translateY(-1px);
+            box-shadow: var(--shadow-md);
+        }
+
+        .btn-secondary {
+            background: var(--border-light);
+            color: var(--text-primary);
+            border: 1px solid var(--border);
+        }
+
+        .btn-secondary:hover {
+            background: var(--border);
+        }
+
+        .btn-danger {
+            background: var(--danger);
+            color: white;
+        }
+
+        .btn-danger:hover {
+            background: #B91C1C;
+            transform: translateY(-1px);
+        }
+
+        /* Security Section */
+        .security-item {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 20px 0;
+            border-bottom: 1px solid var(--border-light);
+        }
+
+        .security-item:last-child {
+            border-bottom: none;
+        }
+
+        .security-info h4 {
+            font-size: 16px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+        }
+
+        .security-info p {
+            font-size: 14px;
+            color: var(--text-secondary);
+        }
+
+        .security-status {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 14px;
+            font-weight: 500;
+        }
+
+        .status-icon {
+            width: 20px;
+            height: 20px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 12px;
+            color: white;
+        }
+
+        .status-verified {
+            background: var(--success);
+        }
+
+        .status-pending {
+            background: var(--warning);
+        }
+
+        /* Activity Log */
+        .activity-log {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            box-shadow: var(--shadow);
+        }
+
+        .section-title {
+            font-size: 22px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 24px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .activity-item {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            padding: 16px 0;
+            border-bottom: 1px solid var(--border-light);
+        }
+
+        .activity-item:last-child {
+            border-bottom: none;
+        }
+
+        .activity-icon {
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 16px;
+            color: white;
+        }
+
+        .activity-login {
+            background: var(--accent);
+        }
+
+        .activity-investment {
+            background: var(--success);
+        }
+
+        .activity-withdrawal {
+            background: var(--warning);
+        }
+
+        .activity-referral {
+            background: var(--purple);
+        }
+
+        .activity-details h4 {
+            font-size: 14px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 2px;
+        }
+
+        .activity-details p {
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        .activity-time {
+            margin-left: auto;
+            font-size: 12px;
+            color: var(--text-muted);
+        }
+
+        /* Hidden file input */
+        .file-input {
+            display: none;
+        }
+
+        /* Toggle Switch */
+        .toggle-switch {
+            position: relative;
+            width: 50px;
+            height: 24px;
+            background: var(--border);
+            border-radius: 12px;
+            cursor: pointer;
+            transition: all 0.3s ease;
+        }
+
+        .toggle-switch.active {
+            background: var(--accent);
+        }
+
+        .toggle-switch::before {
+            content: '';
+            position: absolute;
+            width: 20px;
+            height: 20px;
+            background: white;
+            border-radius: 50%;
+            top: 2px;
+            left: 2px;
+            transition: all 0.3s ease;
+        }
+
+        .toggle-switch.active::before {
+            transform: translateX(26px);
+        }
+
+        .notification-setting {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 16px 0;
+            border-bottom: 1px solid var(--border-light);
+        }
+
+        .notification-setting:last-child {
+            border-bottom: none;
+        }
+
+        /* Responsive */
+        @media (max-width: 1024px) {
+            .sidebar {
+                transform: translateX(-100%);
+                transition: transform 0.3s ease;
+            }
+            
+            .sidebar.open {
+                transform: translateX(0);
+            }
+            
+            .main-content {
+                margin-left: 0;
+                max-width: 100vw;
+                padding: 20px;
+            }
+            
+            .hamburger {
+                display: flex;
+            }
+
+            .profile-grid {
+                grid-template-columns: 1fr;
+                gap: 24px;
+            }
+
+            .form-row {
+                grid-template-columns: 1fr;
+            }
+
+            .settings-tabs {
+                flex-direction: column;
+            }
+        }
+
+        /* Animations */
+        @keyframes slideIn {
+            from {
+                transform: translateY(-20px);
+                opacity: 0;
+            }
+            to {
+                transform: translateY(0);
+                opacity: 1;
+            }
+        }
+
+        .tab-content.active {
+            animation: slideIn 0.3s ease;
+        }
+    </style>
+</head>
+
+<body>
+    <!-- Fixed Header -->
+    <header class="fixed-header">
+        <div class="header-left">
+            <button class="hamburger" onclick="toggleSidebar()">
+                <i class="fas fa-bars"></i>
+            </button>
+            <div class="header-title">FinverPro</div>
+        </div>
+    </header>
+
+    <!-- Sidebar -->
+    <nav class="sidebar" id="sidebar">
+        <div class="sidebar-content">
+            <div class="nav-section">
+                <div class="nav-section-title">Básico</div>
+                <a href="../dashboard/" class="nav-item">
+                    <i class="fas fa-home"></i>
+                    Início
+                </a>
+                <a href="../equipe/" class="nav-item">
+                    <i class="fas fa-users"></i>
+                    Equipe
+                </a>
+                <a href="#" class="nav-item active">
+                    <i class="fas fa-user-circle"></i>
+                    Perfil
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Investimentos</div>
+                <a href="../investimentos/" class="nav-item">
+                    <i class="fas fa-coins"></i>
+                    Produtos
+                </a>
+                <a href="../investimentos/" class="nav-item">
+                    <i class="fas fa-chart-line"></i>
+                    Meus Investimentos
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Diversão</div>
+                <a href="../roleta/" class="nav-item">
+                    <i class="fas fa-magic"></i>
+                    Roleta da Sorte
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Estatísticas</div>
+                <a href="../relatorios/" class="nav-item">
+                    <i class="fas fa-chart-bar"></i>
+                    Relatórios
+                </a>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Main Content -->
+    <main class="main-content">
+        <!-- Header -->
+        <div class="header">
+            <div class="header-left">
+                <h1>👤 Meu Perfil</h1>
+                <p>Gerencie suas informações pessoais e configurações</p>
+            </div>
+        </div>
+
+        <!-- Profile Grid -->
+        <div class="profile-grid">
+            <!-- Profile Card -->
+            <div class="profile-card">
+                <div class="profile-avatar">
+                    JI
+                    <div class="avatar-upload" onclick="uploadAvatar()">
+                        <i class="fas fa-camera"></i>
+                    </div>
+                </div>
+                
+                <h2 class="profile-name">João Investidor</h2>
+                <div class="profile-level">⭐ Investidor Gold</div>
+                
+                <div class="profile-stats">
+                    <div class="profile-stat">
+                        <div class="profile-stat-value">3 anos</div>
+                        <div class="profile-stat-label">Membro desde</div>
+                    </div>
+                    <div class="profile-stat">
+                        <div class="profile-stat-value">156</div>
+                        <div class="profile-stat-label">Indicações</div>
+                    </div>
+                </div>
+                
+                <button class="btn btn-primary" style="width: 100%;">
+                    <i class="fas fa-crown"></i>
+                    Upgrade para Diamond
+                </button>
+            </div>
+
+            <!-- Settings Card -->
+            <div class="settings-card">
+                <div class="settings-tabs">
+                    <button class="tab-btn active" onclick="showTab('personal')">
+                        <i class="fas fa-user"></i>
+                        Dados Pessoais
+                    </button>
+                    <button class="tab-btn" onclick="showTab('security')">
+                        <i class="fas fa-shield-alt"></i>
+                        Segurança
+                    </button>
+                    <button class="tab-btn" onclick="showTab('notifications')">
+                        <i class="fas fa-bell"></i>
+                        Notificações
+                    </button>
+                </div>
+
+                <!-- Personal Information Tab -->
+                <div class="tab-content active" id="personal">
+                    <form>
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label class="form-label">Nome Completo</label>
+                                <input type="text" class="form-input" value="João Investidor Silva" placeholder="Digite seu nome completo">
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label">CPF</label>
+                                <input type="text" class="form-input" value="***.***.***-**" disabled>
+                                <div class="form-info">CPF não pode ser alterado</div>
+                            </div>
+                        </div>
+
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label class="form-label">E-mail</label>
+                                <input type="email" class="form-input" value="joao@email.com" placeholder="Digite seu e-mail">
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label">Telefone</label>
+                                <input type="tel" class="form-input" value="(11) 99999-9999" placeholder="Digite seu telefone">
+                            </div>
+                        </div>
+
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label class="form-label">Data de Nascimento</label>
+                                <input type="date" class="form-input" value="1990-01-15">
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label">Estado Civil</label>
+                                <select class="form-input">
+                                    <option>Solteiro</option>
+                                    <option selected>Casado</option>
+                                    <option>Divorciado</option>
+                                    <option>Viúvo</option>
+                                </select>
+                            </div>
+                        </div>
+
+                        <div class="form-group">
+                            <label class="form-label">Endereço Completo</label>
+                            <input type="text" class="form-input" value="Rua das Flores, 123 - Centro - São Paulo/SP" placeholder="Digite seu endereço">
+                        </div>
+
+                        <div style="display: flex; gap: 12px; justify-content: flex-end;">
+                            <button type="button" class="btn btn-secondary">Cancelar</button>
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-save"></i>
+                                Salvar Alterações
+                            </button>
+                        </div>
+                    </form>
+                </div>
+
+                <!-- Security Tab -->
+                <div class="tab-content" id="security">
+                    <div class="security-item">
+                        <div class="security-info">
+                            <h4>Verificação por E-mail</h4>
+                            <p>Seu e-mail está verificado e protegido</p>
+                        </div>
+                        <div class="security-status">
+                            <div class="status-icon status-verified">
+                                <i class="fas fa-check"></i>
+                            </div>
+                            Verificado
+                        </div>
+                    </div>
+
+                    <div class="security-item">
+                        <div class="security-info">
+                            <h4>Verificação por SMS</h4>
+                            <p>Receba códigos de segurança por SMS</p>
+                        </div>
+                        <div class="security-status">
+                            <div class="status-icon status-verified">
+                                <i class="fas fa-check"></i>
+                            </div>
+                            Ativo
+                        </div>
+                    </div>
+
+                    <div class="security-item">
+                        <div class="security-info">
+                            <h4>Autenticação em Duas Etapas</h4>
+                            <p>Adicione uma camada extra de segurança</p>
+                        </div>
+                        <div class="security-status">
+                            <div class="status-icon status-pending">
+                                <i class="fas fa-clock"></i>
+                            </div>
+                            Configurar
+                        </div>
+                    </div>
+
+                    <hr style="margin: 24px 0; border: none; border-top: 1px solid var(--border-light);">
+
+                    <h3 style="margin-bottom: 20px; font-size: 18px; color: var(--text-primary);">Alterar Senha</h3>
+                    
+                    <form>
+                        <div class="form-group">
+                            <label class="form-label">Senha Atual</label>
+                            <input type="password" class="form-input" placeholder="Digite sua senha atual">
+                        </div>
+
+                        <div class="form-row">
+                            <div class="form-group">
+                                <label class="form-label">Nova Senha</label>
+                                <input type="password" class="form-input" placeholder="Digite sua nova senha">
+                            </div>
+                            <div class="form-group">
+                                <label class="form-label">Confirmar Nova Senha</label>
+                                <input type="password" class="form-input" placeholder="Confirme sua nova senha">
+                            </div>
+                        </div>
+
+                        <div style="display: flex; gap: 12px; justify-content: flex-end;">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fas fa-lock"></i>
+                                Alterar Senha
+                            </button>
+                        </div>
+                    </form>
+                </div>
+
+                <!-- Notifications Tab -->
+                <div class="tab-content" id="notifications">
+                    <div class="notification-setting">
+                        <div>
+                            <h4 style="font-size: 16px; font-weight: 600; margin-bottom: 4px;">Notificações por E-mail</h4>
+                            <p style="font-size: 14px; color: var(--text-secondary);">Receba atualizações sobre seus investimentos</p>
+                        </div>
+                        <div class="toggle-switch active" onclick="toggleNotification(this)"></div>
+                    </div>
+
+                    <div class="notification-setting">
+                        <div>
+                            <h4 style="font-size: 16px; font-weight: 600; margin-bottom: 4px;">Notificações por SMS</h4>
+                            <p style="font-size: 14px; color: var(--text-secondary);">Alertas importantes via mensagem de texto</p>
+                        </div>
+                        <div class="toggle-switch active" onclick="toggleNotification(this)"></div>
+                    </div>
+
+                    <div class="notification-setting">
+                        <div>
+                            <h4 style="font-size: 16px; font-weight: 600; margin-bottom: 4px;">Alertas de Rendimento</h4>
+                            <p style="font-size: 14px; color: var(--text-secondary);">Seja notificado quando seus investimentos renderem</p>
+                        </div>
+                        <div class="toggle-switch active" onclick="toggleNotification(this)"></div>
+                    </div>
+
+                    <div class="notification-setting">
+                        <div>
+                            <h4 style="font-size: 16px; font-weight: 600; margin-bottom: 4px;">Newsletter Semanal</h4>
+                            <p style="font-size: 14px; color: var(--text-secondary);">Resumo semanal de suas atividades</p>
+                        </div>
+                        <div class="toggle-switch" onclick="toggleNotification(this)"></div>
+                    </div>
+
+                    <div class="notification-setting">
+                        <div>
+                            <h4 style="font-size: 16px; font-weight: 600; margin-bottom: 4px;">Alertas de Segurança</h4>
+                            <p style="font-size: 14px; color: var(--text-secondary);">Notificações sobre atividades suspeitas</p>
+                        </div>
+                        <div class="toggle-switch active" onclick="toggleNotification(this)"></div>
+                    </div>
+
+                    <hr style="margin: 24px 0; border: none; border-top: 1px solid var(--border-light);">
+
+                    <div style="display: flex; gap: 12px; justify-content: flex-end;">
+                        <button type="button" class="btn btn-danger">
+                            <i class="fas fa-user-times"></i>
+                            Excluir Conta
+                        </button>
+                        <button type="button" class="btn btn-primary">
+                            <i class="fas fa-save"></i>
+                            Salvar Preferências
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Activity Log -->
+        <div class="activity-log">
+            <h2 class="section-title">
+                <i class="fas fa-history"></i>
+                Atividades Recentes
+            </h2>
+            
+            <div class="activity-item">
+                <div class="activity-icon activity-login">
+                    <i class="fas fa-sign-in-alt"></i>
+                </div>
+                <div class="activity-details">
+                    <h4>Login realizado</h4>
+                    <p>Acesso via dispositivo móvel - IP: 192.168.1.1</p>
+                </div>
+                <div class="activity-time">Agora</div>
+            </div>
+
+            <div class="activity-item">
+                <div class="activity-icon activity-investment">
+                    <i class="fas fa-coins"></i>
+                </div>
+                <div class="activity-details">
+                    <h4>Investimento realizado</h4>
+                    <p>R$ 5.000,00 em Renda Fixa Premium</p>
+                </div>
+                <div class="activity-time">2 horas atrás</div>
+            </div>
+
+            <div class="activity-item">
+                <div class="activity-icon activity-referral">
+                    <i class="fas fa-user-plus"></i>
+                </div>
+                <div class="activity-details">
+                    <h4>Nova indicação</h4>
+                    <p>Ana Costa se cadastrou usando seu código</p>
+                </div>
+                <div class="activity-time">1 dia atrás</div>
+            </div>
+
+            <div class="activity-item">
+                <div class="activity-icon activity-withdrawal">
+                    <i class="fas fa-arrow-up"></i>
+                </div>
+                <div class="activity-details">
+                    <h4>Saque solicitado</h4>
+                    <p>R$ 1.500,00 via PIX - Processando</p>
+                </div>
+                <div class="activity-time">2 dias atrás</div>
+            </div>
+
+            <div class="activity-item">
+                <div class="activity-icon activity-investment">
+                    <i class="fas fa-chart-line"></i>
+                </div>
+                <div class="activity-details">
+                    <h4>Rendimento creditado</h4>
+                    <p>R$ 152,30 de rendimentos do Elite Invest</p>
+                </div>
+                <div class="activity-time">3 dias atrás</div>
+            </div>
+        </div>
+    </main>
+
+    <!-- Hidden file input for avatar upload -->
+    <input type="file" class="file-input" id="avatarInput" accept="image/*" onchange="handleAvatarUpload(event)">
+
+    <script>
+        // Sidebar toggle for mobile
+        function toggleSidebar() {
+            const sidebar = document.getElementById('sidebar');
+            sidebar.classList.toggle('open');
+        }
+
+        // Tab switching
+        function showTab(tabName) {
+            // Hide all tab contents
+            document.querySelectorAll('.tab-content').forEach(content => {
+                content.classList.remove('active');
+            });
+            
+            // Remove active from all tab buttons
+            document.querySelectorAll('.tab-btn').forEach(btn => {
+                btn.classList.remove('active');
+            });
+            
+            // Show selected tab content
+            document.getElementById(tabName).classList.add('active');
+            
+            // Add active to clicked tab button
+            event.target.classList.add('active');
+        }
+
+        // Avatar upload
+        function uploadAvatar() {
+            document.getElementById('avatarInput').click();
+        }
+
+        function handleAvatarUpload(event) {
+            const file = event.target.files[0];
+            if (file) {
+                const reader = new FileReader();
+                reader.onload = function(e) {
+                    const avatar = document.querySelector('.profile-avatar');
+                    avatar.innerHTML = `
+                        <img src="${e.target.result}" alt="Avatar">
+                        <div class="avatar-upload" onclick="uploadAvatar()">
+                            <i class="fas fa-camera"></i>
+                        </div>
+                    `;
+                };
+                reader.readAsDataURL(file);
+            }
+        }
+
+        // Toggle notifications
+        function toggleNotification(element) {
+            element.classList.toggle('active');
+        }
+
+        // Form submissions
+        document.addEventListener('DOMContentLoaded', function() {
+            // Personal info form
+            const personalForm = document.querySelector('#personal form');
+            personalForm.addEventListener('submit', function(e) {
+                e.preventDefault();
+                showToast('Informações pessoais atualizadas com sucesso!', 'success');
+            });
+
+            // Security form
+            const securityForm = document.querySelector('#security form');
+            securityForm.addEventListener('submit', function(e) {
+                e.preventDefault();
+                const currentPassword = e.target.querySelector('input[placeholder="Digite sua senha atual"]').value;
+                const newPassword = e.target.querySelector('input[placeholder="Digite sua nova senha"]').value;
+                const confirmPassword = e.target.querySelector('input[placeholder="Confirme sua nova senha"]').value;
+
+                if (!currentPassword || !newPassword || !confirmPassword) {
+                    showToast('Por favor, preencha todos os campos', 'error');
+                    return;
+                }
+
+                if (newPassword !== confirmPassword) {
+                    showToast('As senhas não coincidem', 'error');
+                    return;
+                }
+
+                if (newPassword.length < 6) {
+                    showToast('A nova senha deve ter pelo menos 6 caracteres', 'error');
+                    return;
+                }
+
+                showToast('Senha alterada com sucesso!', 'success');
+                e.target.reset();
+            });
+        });
+
+        // Toast notification system
+        function showToast(message, type = 'success', duration = 4000) {
+            // Remove existing toasts
+            const existingToasts = document.querySelectorAll('.toast');
+            existingToasts.forEach(toast => toast.remove());
+
+            const toast = document.createElement('div');
+            toast.className = `toast toast-${type}`;
+            toast.style.cssText = `
+                position: fixed;
+                top: 96px;
+                right: 24px;
+                background: var(--bg-card);
+                border: 1px solid var(--border);
+                border-left: 4px solid var(--${type === 'success' ? 'success' : type === 'error' ? 'danger' : 'accent'});
+                border-radius: var(--radius-lg);
+                padding: 16px 20px;
+                box-shadow: var(--shadow-lg);
+                z-index: 10000;
+                opacity: 0;
+                transform: translateX(100px);
+                transition: all 0.3s ease;
+                min-width: 300px;
+                max-width: 400px;
+            `;
+            
+            toast.innerHTML = `
+                <div style="display: flex; align-items: center; gap: 12px;">
+                    <i class="fas ${type === 'success' ? 'fa-check-circle' : type === 'error' ? 'fa-exclamation-circle' : 'fa-info-circle'}" 
+                       style="color: var(--${type === 'success' ? 'success' : type === 'error' ? 'danger' : 'accent'});"></i>
+                    <span style="flex: 1; font-size: 14px; font-weight: 500; color: var(--text-primary);">${message}</span>
+                    <button onclick="this.parentElement.parentElement.remove()" 
+                            style="background: none; border: none; color: var(--text-muted); cursor: pointer; padding: 0; font-size: 16px;">
+                        <i class="fas fa-times"></i>
+                    </button>
+                </div>
+            `;
+            
+            document.body.appendChild(toast);
+            
+            // Show toast
+            setTimeout(() => {
+                toast.style.opacity = '1';
+                toast.style.transform = 'translateX(0)';
+            }, 100);
+            
+            // Auto remove toast
+            setTimeout(() => {
+                toast.style.opacity = '0';
+                toast.style.transform = 'translateX(100px)';
+                setTimeout(() => {
+                    toast.remove();
+                }, 300);
+            }, duration);
+        }
+
+        // Close sidebar when clicking outside on mobile
+        document.addEventListener('click', function(event) {
+            const sidebar = document.getElementById('sidebar');
+            const hamburger = document.querySelector('.hamburger');
+            
+            if (window.innerWidth <= 1024 && !sidebar.contains(event.target) && !hamburger.contains(event.target)) {
+                sidebar.classList.remove('open');
+            }
+        });
+
+        // Responsive handling
+        window.addEventListener('resize', function() {
+            const sidebar = document.getElementById('sidebar');
+            if (window.innerWidth > 1024) {
+                sidebar.classList.remove('open');
+            }
+        });
+    </script>
+</body>
+</html>

--- a/design/relatorios/index.html
+++ b/design/relatorios/index.html
@@ -1,0 +1,1215 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FinverPro - Relatórios</title>
+    
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Roboto:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    
+    <style>
+        :root {
+            --bg-primary: #F8FAFC;
+            --bg-secondary: #FFFFFF;
+            --bg-sidebar: #1E293B;
+            --bg-card: #FFFFFF;
+            --bg-header: #FFFFFF;
+            
+            --primary: #0F172A;
+            --primary-light: #334155;
+            --accent: #3B82F6;
+            --success: #059669;
+            --warning: #D97706;
+            --danger: #DC2626;
+            --purple: #8B5CF6;
+            --pink: #EC4899;
+            --orange: #F97316;
+            
+            --text-primary: #0F172A;
+            --text-secondary: #64748B;
+            --text-muted: #94A3B8;
+            --text-white: #FFFFFF;
+            
+            --border: #E2E8F0;
+            --border-light: #F1F5F9;
+            
+            --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+            
+            --radius: 8px;
+            --radius-lg: 12px;
+        }
+
+        [data-theme="dark"] {
+            --bg-primary: #0F172A;
+            --bg-secondary: #1E293B;
+            --bg-sidebar: #0F172A;
+            --bg-card: #1E293B;
+            --bg-header: #1E293B;
+            
+            --primary: #F8FAFC;
+            --primary-light: #E2E8F0;
+            --accent: #3B82F6;
+            --success: #10B981;
+            --warning: #F59E0B;
+            --danger: #EF4444;
+            
+            --text-primary: #F8FAFC;
+            --text-secondary: #94A3B8;
+            --text-muted: #64748B;
+            --text-white: #FFFFFF;
+            
+            --border: #334155;
+            --border-light: #475569;
+            
+            --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3);
+            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.3);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Inter', sans-serif;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            line-height: 1.5;
+            display: flex;
+            min-height: 100vh;
+            transition: all 0.3s ease;
+        }
+
+        /* Fixed Header */
+        .fixed-header {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            background: var(--bg-header);
+            border-bottom: 1px solid var(--border);
+            padding: 16px 24px;
+            z-index: 1000;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            box-shadow: var(--shadow);
+        }
+
+        .header-left {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+        }
+
+        .hamburger {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            width: 40px;
+            height: 40px;
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            cursor: pointer;
+            box-shadow: var(--shadow);
+        }
+
+        .header-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: var(--text-primary);
+            font-family: 'Roboto', sans-serif;
+        }
+
+        /* Sidebar */
+        .sidebar {
+            width: 280px;
+            background: var(--bg-sidebar);
+            color: var(--text-white);
+            padding: 0;
+            position: fixed;
+            height: 100vh;
+            left: 0;
+            top: 72px;
+            z-index: 100;
+            display: flex;
+            flex-direction: column;
+            box-shadow: var(--shadow-lg);
+            transition: all 0.3s ease;
+        }
+
+        .sidebar-content {
+            flex: 1;
+            overflow-y: auto;
+            padding: 24px 0;
+        }
+
+        .nav-section {
+            margin-bottom: 32px;
+        }
+
+        .nav-section-title {
+            font-size: 12px;
+            font-weight: 600;
+            color: rgba(255, 255, 255, 0.5);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 16px;
+            padding: 0 24px;
+        }
+
+        .nav-item {
+            display: flex;
+            align-items: center;
+            padding: 12px 24px;
+            color: rgba(255, 255, 255, 0.8);
+            text-decoration: none;
+            transition: all 0.2s ease;
+            font-weight: 500;
+            border-right: 3px solid transparent;
+        }
+
+        .nav-item:hover {
+            background: rgba(255, 255, 255, 0.05);
+            color: var(--text-white);
+        }
+
+        .nav-item.active {
+            background: rgba(59, 130, 246, 0.1);
+            color: #3B82F6;
+            border-right-color: #3B82F6;
+        }
+
+        .nav-item i {
+            width: 20px;
+            margin-right: 12px;
+            font-size: 16px;
+        }
+
+        /* Main content */
+        .main-content {
+            flex: 1;
+            margin-left: 280px;
+            margin-top: 72px;
+            padding: 32px;
+            max-width: calc(100vw - 280px);
+        }
+
+        /* Header */
+        .header {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px 32px;
+            margin-bottom: 32px;
+            box-shadow: var(--shadow);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .header-left h1 {
+            font-size: 28px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+            font-family: 'Roboto', sans-serif;
+        }
+
+        .header-left p {
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
+        /* Period Selector */
+        .period-selector {
+            display: flex;
+            gap: 8px;
+            background: var(--bg-primary);
+            border-radius: var(--radius);
+            padding: 4px;
+        }
+
+        .period-btn {
+            background: none;
+            border: none;
+            padding: 8px 16px;
+            border-radius: var(--radius);
+            color: var(--text-secondary);
+            font-weight: 500;
+            cursor: pointer;
+            font-size: 14px;
+            transition: all 0.2s ease;
+        }
+
+        .period-btn.active {
+            background: var(--bg-card);
+            color: var(--accent);
+            box-shadow: var(--shadow);
+        }
+
+        .period-btn:hover {
+            color: var(--text-primary);
+        }
+
+        /* Overview Grid */
+        .overview-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+            gap: 24px;
+            margin-bottom: 32px;
+        }
+
+        .overview-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            box-shadow: var(--shadow);
+            transition: all 0.2s ease;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .overview-card:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-md);
+        }
+
+        .overview-card::before {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 4px;
+            background: linear-gradient(90deg, var(--accent), var(--success));
+        }
+
+        .overview-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 16px;
+        }
+
+        .overview-icon {
+            width: 48px;
+            height: 48px;
+            background: linear-gradient(135deg, var(--accent), var(--purple));
+            color: white;
+            border-radius: var(--radius);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 20px;
+        }
+
+        .overview-change {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            font-size: 12px;
+            font-weight: 600;
+            padding: 4px 8px;
+            border-radius: 12px;
+        }
+
+        .change-positive {
+            background: rgba(5, 150, 105, 0.1);
+            color: var(--success);
+        }
+
+        .change-negative {
+            background: rgba(220, 38, 38, 0.1);
+            color: var(--danger);
+        }
+
+        .overview-value {
+            font-size: 28px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+            font-family: 'Roboto', sans-serif;
+        }
+
+        .overview-label {
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
+        /* Chart Grid */
+        .chart-grid {
+            display: grid;
+            grid-template-columns: 2fr 1fr;
+            gap: 24px;
+            margin-bottom: 32px;
+        }
+
+        .chart-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            box-shadow: var(--shadow);
+        }
+
+        .chart-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 24px;
+        }
+
+        .chart-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: var(--text-primary);
+        }
+
+        .chart-info {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
+        .chart-container {
+            position: relative;
+            height: 300px;
+        }
+
+        /* Table Styles */
+        .table-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            box-shadow: var(--shadow);
+            overflow: hidden;
+        }
+
+        .table-header {
+            padding: 24px 24px 0;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+        }
+
+        .table-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: var(--text-primary);
+        }
+
+        .table-actions {
+            display: flex;
+            gap: 8px;
+        }
+
+        .table-btn {
+            background: var(--bg-primary);
+            border: 1px solid var(--border);
+            color: var(--text-primary);
+            padding: 8px 12px;
+            border-radius: var(--radius);
+            cursor: pointer;
+            font-size: 12px;
+            transition: all 0.2s ease;
+        }
+
+        .table-btn:hover {
+            border-color: var(--accent);
+        }
+
+        .data-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin-top: 16px;
+        }
+
+        .data-table th,
+        .data-table td {
+            padding: 16px 24px;
+            text-align: left;
+            border-bottom: 1px solid var(--border-light);
+        }
+
+        .data-table th {
+            background: var(--bg-primary);
+            font-weight: 600;
+            color: var(--text-primary);
+            font-size: 14px;
+        }
+
+        .data-table td {
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
+        .data-table tbody tr:hover {
+            background: var(--bg-primary);
+        }
+
+        /* Status Badges */
+        .status-badge {
+            display: inline-block;
+            padding: 4px 8px;
+            border-radius: 12px;
+            font-size: 12px;
+            font-weight: 600;
+        }
+
+        .status-active {
+            background: rgba(5, 150, 105, 0.1);
+            color: var(--success);
+        }
+
+        .status-completed {
+            background: rgba(59, 130, 246, 0.1);
+            color: var(--accent);
+        }
+
+        .status-pending {
+            background: rgba(217, 119, 6, 0.1);
+            color: var(--warning);
+        }
+
+        /* Investment Performance */
+        .performance-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 24px;
+        }
+
+        .performance-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            box-shadow: var(--shadow);
+        }
+
+        .performance-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 20px;
+        }
+
+        .performance-title {
+            font-size: 16px;
+            font-weight: 600;
+            color: var(--text-primary);
+        }
+
+        .performance-return {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            font-size: 14px;
+            font-weight: 600;
+        }
+
+        .return-positive {
+            color: var(--success);
+        }
+
+        .return-negative {
+            color: var(--danger);
+        }
+
+        .performance-details {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 16px;
+        }
+
+        .performance-detail {
+            text-align: center;
+        }
+
+        .performance-detail-value {
+            font-size: 18px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+        }
+
+        .performance-detail-label {
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        /* Section Title */
+        .section-title {
+            font-size: 22px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 24px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        /* Export Button */
+        .export-btn {
+            background: linear-gradient(135deg, var(--accent), var(--purple));
+            color: white;
+            border: none;
+            padding: 12px 20px;
+            border-radius: var(--radius);
+            font-weight: 600;
+            cursor: pointer;
+            font-size: 14px;
+            transition: all 0.2s ease;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .export-btn:hover {
+            transform: translateY(-1px);
+            box-shadow: var(--shadow-md);
+        }
+
+        /* Responsive */
+        @media (max-width: 1024px) {
+            .sidebar {
+                transform: translateX(-100%);
+                transition: transform 0.3s ease;
+            }
+            
+            .sidebar.open {
+                transform: translateX(0);
+            }
+            
+            .main-content {
+                margin-left: 0;
+                max-width: 100vw;
+                padding: 20px;
+            }
+            
+            .hamburger {
+                display: flex;
+            }
+
+            .chart-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .overview-grid {
+                grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            }
+
+            .period-selector {
+                flex-wrap: wrap;
+            }
+
+            .performance-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .header {
+                flex-direction: column;
+                align-items: flex-start;
+                gap: 16px;
+            }
+
+            .data-table {
+                font-size: 12px;
+            }
+
+            .data-table th,
+            .data-table td {
+                padding: 12px 16px;
+            }
+        }
+
+        /* Legend */
+        .chart-legend {
+            display: flex;
+            gap: 16px;
+            margin-top: 16px;
+            flex-wrap: wrap;
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 14px;
+            color: var(--text-secondary);
+        }
+
+        .legend-color {
+            width: 12px;
+            height: 12px;
+            border-radius: 2px;
+        }
+
+        /* Loading State */
+        .loading {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            height: 200px;
+            color: var(--text-muted);
+        }
+
+        .spinner {
+            animation: spin 1s linear infinite;
+            margin-right: 8px;
+        }
+
+        @keyframes spin {
+            from { transform: rotate(0deg); }
+            to { transform: rotate(360deg); }
+        }
+    </style>
+</head>
+
+<body>
+    <!-- Fixed Header -->
+    <header class="fixed-header">
+        <div class="header-left">
+            <button class="hamburger" onclick="toggleSidebar()">
+                <i class="fas fa-bars"></i>
+            </button>
+            <div class="header-title">FinverPro</div>
+        </div>
+    </header>
+
+    <!-- Sidebar -->
+    <nav class="sidebar" id="sidebar">
+        <div class="sidebar-content">
+            <div class="nav-section">
+                <div class="nav-section-title">Básico</div>
+                <a href="../dashboard/" class="nav-item">
+                    <i class="fas fa-home"></i>
+                    Início
+                </a>
+                <a href="../equipe/" class="nav-item">
+                    <i class="fas fa-users"></i>
+                    Equipe
+                </a>
+                <a href="../perfil/" class="nav-item">
+                    <i class="fas fa-user-circle"></i>
+                    Perfil
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Investimentos</div>
+                <a href="../investimentos/" class="nav-item">
+                    <i class="fas fa-coins"></i>
+                    Produtos
+                </a>
+                <a href="../investimentos/" class="nav-item">
+                    <i class="fas fa-chart-line"></i>
+                    Meus Investimentos
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Diversão</div>
+                <a href="../roleta/" class="nav-item">
+                    <i class="fas fa-magic"></i>
+                    Roleta da Sorte
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Estatísticas</div>
+                <a href="#" class="nav-item active">
+                    <i class="fas fa-chart-bar"></i>
+                    Relatórios
+                </a>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Main Content -->
+    <main class="main-content">
+        <!-- Header -->
+        <div class="header">
+            <div class="header-left">
+                <h1>📊 Relatórios</h1>
+                <p>Análise completa dos seus investimentos e indicações</p>
+            </div>
+            
+            <div style="display: flex; gap: 16px; align-items: center;">
+                <div class="period-selector">
+                    <button class="period-btn" onclick="changePeriod('7d')">7 dias</button>
+                    <button class="period-btn active" onclick="changePeriod('30d')">30 dias</button>
+                    <button class="period-btn" onclick="changePeriod('90d')">90 dias</button>
+                    <button class="period-btn" onclick="changePeriod('1y')">1 ano</button>
+                </div>
+                
+                <button class="export-btn" onclick="exportReport()">
+                    <i class="fas fa-download"></i>
+                    Exportar
+                </button>
+            </div>
+        </div>
+
+        <!-- Overview Grid -->
+        <div class="overview-grid">
+            <div class="overview-card">
+                <div class="overview-header">
+                    <div class="overview-icon">
+                        <i class="fas fa-chart-line"></i>
+                    </div>
+                    <div class="overview-change change-positive">
+                        <i class="fas fa-arrow-up"></i>
+                        +12.5%
+                    </div>
+                </div>
+                <div class="overview-value">R$ 52.847,32</div>
+                <div class="overview-label">Patrimônio Total</div>
+            </div>
+
+            <div class="overview-card">
+                <div class="overview-header">
+                    <div class="overview-icon">
+                        <i class="fas fa-coins"></i>
+                    </div>
+                    <div class="overview-change change-positive">
+                        <i class="fas fa-arrow-up"></i>
+                        +8.3%
+                    </div>
+                </div>
+                <div class="overview-value">R$ 4.285,67</div>
+                <div class="overview-label">Rendimento Mensal</div>
+            </div>
+
+            <div class="overview-card">
+                <div class="overview-header">
+                    <div class="overview-icon">
+                        <i class="fas fa-users"></i>
+                    </div>
+                    <div class="overview-change change-positive">
+                        <i class="fas fa-arrow-up"></i>
+                        +24
+                    </div>
+                </div>
+                <div class="overview-value">156</div>
+                <div class="overview-label">Indicações Ativas</div>
+            </div>
+
+            <div class="overview-card">
+                <div class="overview-header">
+                    <div class="overview-icon">
+                        <i class="fas fa-percentage"></i>
+                    </div>
+                    <div class="overview-change change-positive">
+                        <i class="fas fa-arrow-up"></i>
+                        +2.1%
+                    </div>
+                </div>
+                <div class="overview-value">18.7%</div>
+                <div class="overview-label">ROI Médio</div>
+            </div>
+        </div>
+
+        <!-- Chart Grid -->
+        <div class="chart-grid">
+            <!-- Performance Chart -->
+            <div class="chart-card">
+                <div class="chart-header">
+                    <h3 class="chart-title">Evolução do Patrimônio</h3>
+                    <div class="chart-info">
+                        <i class="fas fa-info-circle"></i>
+                        Últimos 12 meses
+                    </div>
+                </div>
+                <div class="chart-container">
+                    <canvas id="performanceChart"></canvas>
+                </div>
+                <div class="chart-legend">
+                    <div class="legend-item">
+                        <div class="legend-color" style="background: #3B82F6;"></div>
+                        Patrimônio Total
+                    </div>
+                    <div class="legend-item">
+                        <div class="legend-color" style="background: #059669;"></div>
+                        Rendimentos
+                    </div>
+                </div>
+            </div>
+
+            <!-- Portfolio Distribution -->
+            <div class="chart-card">
+                <div class="chart-header">
+                    <h3 class="chart-title">Distribuição da Carteira</h3>
+                    <div class="chart-info">
+                        <i class="fas fa-pie-chart"></i>
+                        Por produto
+                    </div>
+                </div>
+                <div class="chart-container">
+                    <canvas id="portfolioChart"></canvas>
+                </div>
+                <div class="chart-legend">
+                    <div class="legend-item">
+                        <div class="legend-color" style="background: #3B82F6;"></div>
+                        Renda Fixa Premium
+                    </div>
+                    <div class="legend-item">
+                        <div class="legend-color" style="background: #8B5CF6;"></div>
+                        Multi Plus
+                    </div>
+                    <div class="legend-item">
+                        <div class="legend-color" style="background: #F97316;"></div>
+                        Elite Invest
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Performance Section -->
+        <section>
+            <h2 class="section-title">
+                <i class="fas fa-trophy"></i>
+                Performance dos Investimentos
+            </h2>
+            
+            <div class="performance-grid">
+                <div class="performance-card">
+                    <div class="performance-header">
+                        <h3 class="performance-title">Renda Fixa Premium</h3>
+                        <div class="performance-return return-positive">
+                            <i class="fas fa-arrow-up"></i>
+                            +15.2%
+                        </div>
+                    </div>
+                    <div class="performance-details">
+                        <div class="performance-detail">
+                            <div class="performance-detail-value">R$ 18.547</div>
+                            <div class="performance-detail-label">Investido</div>
+                        </div>
+                        <div class="performance-detail">
+                            <div class="performance-detail-value">R$ 2.819</div>
+                            <div class="performance-detail-label">Rendimento</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="performance-card">
+                    <div class="performance-header">
+                        <h3 class="performance-title">Multi Plus</h3>
+                        <div class="performance-return return-positive">
+                            <i class="fas fa-arrow-up"></i>
+                            +18.7%
+                        </div>
+                    </div>
+                    <div class="performance-details">
+                        <div class="performance-detail">
+                            <div class="performance-detail-value">R$ 22.500</div>
+                            <div class="performance-detail-label">Investido</div>
+                        </div>
+                        <div class="performance-detail">
+                            <div class="performance-detail-value">R$ 4.207</div>
+                            <div class="performance-detail-label">Rendimento</div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="performance-card">
+                    <div class="performance-header">
+                        <h3 class="performance-title">Elite Invest</h3>
+                        <div class="performance-return return-positive">
+                            <i class="fas fa-arrow-up"></i>
+                            +22.1%
+                        </div>
+                    </div>
+                    <div class="performance-details">
+                        <div class="performance-detail">
+                            <div class="performance-detail-value">R$ 15.000</div>
+                            <div class="performance-detail-label">Investido</div>
+                        </div>
+                        <div class="performance-detail">
+                            <div class="performance-detail-value">R$ 3.315</div>
+                            <div class="performance-detail-label">Rendimento</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Recent Transactions -->
+        <section style="margin-top: 32px;">
+            <div class="table-card">
+                <div class="table-header">
+                    <h2 class="table-title">
+                        <i class="fas fa-history"></i>
+                        Transações Recentes
+                    </h2>
+                    <div class="table-actions">
+                        <button class="table-btn">
+                            <i class="fas fa-filter"></i>
+                            Filtrar
+                        </button>
+                        <button class="table-btn">
+                            <i class="fas fa-download"></i>
+                            Exportar
+                        </button>
+                    </div>
+                </div>
+                
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Data</th>
+                            <th>Tipo</th>
+                            <th>Produto</th>
+                            <th>Valor</th>
+                            <th>Status</th>
+                            <th>Ações</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr>
+                            <td>30/01/2024</td>
+                            <td>Investimento</td>
+                            <td>Renda Fixa Premium</td>
+                            <td>R$ 5.000,00</td>
+                            <td><span class="status-badge status-active">Ativo</span></td>
+                            <td>
+                                <button class="table-btn" style="font-size: 12px; padding: 4px 8px;">
+                                    <i class="fas fa-eye"></i>
+                                </button>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>28/01/2024</td>
+                            <td>Rendimento</td>
+                            <td>Multi Plus</td>
+                            <td>R$ 312,50</td>
+                            <td><span class="status-badge status-completed">Creditado</span></td>
+                            <td>
+                                <button class="table-btn" style="font-size: 12px; padding: 4px 8px;">
+                                    <i class="fas fa-eye"></i>
+                                </button>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>25/01/2024</td>
+                            <td>Saque</td>
+                            <td>-</td>
+                            <td>R$ 2.000,00</td>
+                            <td><span class="status-badge status-pending">Processando</span></td>
+                            <td>
+                                <button class="table-btn" style="font-size: 12px; padding: 4px 8px;">
+                                    <i class="fas fa-eye"></i>
+                                </button>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>22/01/2024</td>
+                            <td>Comissão</td>
+                            <td>Indicação</td>
+                            <td>R$ 150,00</td>
+                            <td><span class="status-badge status-completed">Creditado</span></td>
+                            <td>
+                                <button class="table-btn" style="font-size: 12px; padding: 4px 8px;">
+                                    <i class="fas fa-eye"></i>
+                                </button>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>20/01/2024</td>
+                            <td>Investimento</td>
+                            <td>Elite Invest</td>
+                            <td>R$ 10.000,00</td>
+                            <td><span class="status-badge status-active">Ativo</span></td>
+                            <td>
+                                <button class="table-btn" style="font-size: 12px; padding: 4px 8px;">
+                                    <i class="fas fa-eye"></i>
+                                </button>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </section>
+    </main>
+
+    <script>
+        // Sidebar toggle for mobile
+        function toggleSidebar() {
+            const sidebar = document.getElementById('sidebar');
+            sidebar.classList.toggle('open');
+        }
+
+        // Change period
+        function changePeriod(period) {
+            document.querySelectorAll('.period-btn').forEach(btn => {
+                btn.classList.remove('active');
+            });
+            event.target.classList.add('active');
+            
+            // Update charts with new data
+            updateCharts(period);
+        }
+
+        // Export report
+        function exportReport() {
+            // Simulate report generation
+            const btn = event.target;
+            const originalContent = btn.innerHTML;
+            btn.innerHTML = '<i class="fas fa-spinner spinner"></i> Gerando...';
+            btn.disabled = true;
+            
+            setTimeout(() => {
+                btn.innerHTML = originalContent;
+                btn.disabled = false;
+                
+                // Create and download a fake PDF
+                const link = document.createElement('a');
+                link.href = 'data:text/plain;charset=utf-8,Relatório FinverPro - Gerado em ' + new Date().toLocaleDateString();
+                link.download = 'relatorio-finverpro-' + new Date().toISOString().split('T')[0] + '.txt';
+                link.click();
+            }, 2000);
+        }
+
+        // Initialize charts
+        function initializeCharts() {
+            // Performance Chart
+            const performanceCtx = document.getElementById('performanceChart').getContext('2d');
+            new Chart(performanceCtx, {
+                type: 'line',
+                data: {
+                    labels: ['Jan', 'Fev', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Out', 'Nov', 'Dez'],
+                    datasets: [{
+                        label: 'Patrimônio Total',
+                        data: [25000, 28500, 32000, 35500, 38000, 41500, 43000, 46500, 48500, 50200, 51800, 52847],
+                        borderColor: '#3B82F6',
+                        backgroundColor: 'rgba(59, 130, 246, 0.1)',
+                        tension: 0.4,
+                        fill: true
+                    }, {
+                        label: 'Rendimentos',
+                        data: [0, 500, 1200, 2100, 2800, 3600, 4200, 5100, 5900, 6800, 7500, 8400],
+                        borderColor: '#059669',
+                        backgroundColor: 'rgba(5, 150, 105, 0.1)',
+                        tension: 0.4,
+                        fill: true
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: {
+                            display: false
+                        }
+                    },
+                    scales: {
+                        y: {
+                            beginAtZero: true,
+                            ticks: {
+                                callback: function(value) {
+                                    return 'R$ ' + value.toLocaleString('pt-BR');
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+
+            // Portfolio Chart
+            const portfolioCtx = document.getElementById('portfolioChart').getContext('2d');
+            new Chart(portfolioCtx, {
+                type: 'doughnut',
+                data: {
+                    labels: ['Renda Fixa Premium', 'Multi Plus', 'Elite Invest'],
+                    datasets: [{
+                        data: [35, 42, 23],
+                        backgroundColor: ['#3B82F6', '#8B5CF6', '#F97316'],
+                        borderWidth: 0
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                        legend: {
+                            display: false
+                        }
+                    }
+                }
+            });
+        }
+
+        // Update charts with new period data
+        function updateCharts(period) {
+            // This would normally fetch new data from API
+            console.log('Updating charts for period:', period);
+        }
+
+        // Animate numbers on page load
+        function animateNumbers() {
+            const numberElements = document.querySelectorAll('.overview-value, .performance-detail-value');
+            numberElements.forEach(element => {
+                const finalValue = element.textContent;
+                element.textContent = '0';
+                
+                // Extract number from text
+                const numericValue = parseFloat(finalValue.replace(/[^\d,.-]/g, '').replace(',', '.'));
+                if (isNaN(numericValue)) return;
+                
+                let currentValue = 0;
+                const increment = numericValue / 50;
+                const timer = setInterval(() => {
+                    currentValue += increment;
+                    if (currentValue >= numericValue) {
+                        element.textContent = finalValue;
+                        clearInterval(timer);
+                    } else {
+                        if (finalValue.includes('R$')) {
+                            element.textContent = 'R$ ' + Math.floor(currentValue).toLocaleString('pt-BR');
+                        } else if (finalValue.includes('%')) {
+                            element.textContent = currentValue.toFixed(1) + '%';
+                        } else {
+                            element.textContent = Math.floor(currentValue);
+                        }
+                    }
+                }, 20);
+            });
+        }
+
+        // Close sidebar when clicking outside on mobile
+        document.addEventListener('click', function(event) {
+            const sidebar = document.getElementById('sidebar');
+            const hamburger = document.querySelector('.hamburger');
+            
+            if (window.innerWidth <= 1024 && !sidebar.contains(event.target) && !hamburger.contains(event.target)) {
+                sidebar.classList.remove('open');
+            }
+        });
+
+        // Responsive handling
+        window.addEventListener('resize', function() {
+            const sidebar = document.getElementById('sidebar');
+            if (window.innerWidth > 1024) {
+                sidebar.classList.remove('open');
+            }
+        });
+
+        // Initialize page
+        window.addEventListener('load', function() {
+            initializeCharts();
+            setTimeout(animateNumbers, 500);
+        });
+    </script>
+</body>
+</html>

--- a/design/roleta/index.html
+++ b/design/roleta/index.html
@@ -1,0 +1,956 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FinverPro - Roleta da Sorte</title>
+    
+    <!-- Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Roboto:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    
+    <style>
+        :root {
+            --bg-primary: #F8FAFC;
+            --bg-secondary: #FFFFFF;
+            --bg-sidebar: #1E293B;
+            --bg-card: #FFFFFF;
+            --bg-header: #FFFFFF;
+            
+            --primary: #0F172A;
+            --primary-light: #334155;
+            --accent: #3B82F6;
+            --success: #059669;
+            --warning: #D97706;
+            --danger: #DC2626;
+            --purple: #8B5CF6;
+            --pink: #EC4899;
+            --orange: #F97316;
+            
+            --text-primary: #0F172A;
+            --text-secondary: #64748B;
+            --text-muted: #94A3B8;
+            --text-white: #FFFFFF;
+            
+            --border: #E2E8F0;
+            --border-light: #F1F5F9;
+            
+            --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1);
+            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+            
+            --radius: 8px;
+            --radius-lg: 12px;
+        }
+
+        [data-theme="dark"] {
+            --bg-primary: #0F172A;
+            --bg-secondary: #1E293B;
+            --bg-sidebar: #0F172A;
+            --bg-card: #1E293B;
+            --bg-header: #1E293B;
+            
+            --primary: #F8FAFC;
+            --primary-light: #E2E8F0;
+            --accent: #3B82F6;
+            --success: #10B981;
+            --warning: #F59E0B;
+            --danger: #EF4444;
+            
+            --text-primary: #F8FAFC;
+            --text-secondary: #94A3B8;
+            --text-muted: #64748B;
+            --text-white: #FFFFFF;
+            
+            --border: #334155;
+            --border-light: #475569;
+            
+            --shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.3);
+            --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.3);
+            --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.3);
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'Inter', sans-serif;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            line-height: 1.5;
+            display: flex;
+            min-height: 100vh;
+            transition: all 0.3s ease;
+        }
+
+        /* Fixed Header */
+        .fixed-header {
+            position: fixed;
+            top: 0;
+            left: 0;
+            right: 0;
+            background: var(--bg-header);
+            border-bottom: 1px solid var(--border);
+            padding: 16px 24px;
+            z-index: 1000;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            box-shadow: var(--shadow);
+        }
+
+        .header-left {
+            display: flex;
+            align-items: center;
+            gap: 16px;
+        }
+
+        .hamburger {
+            display: none;
+            align-items: center;
+            justify-content: center;
+            width: 40px;
+            height: 40px;
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius);
+            cursor: pointer;
+            box-shadow: var(--shadow);
+        }
+
+        .header-title {
+            font-size: 18px;
+            font-weight: 600;
+            color: var(--text-primary);
+            font-family: 'Roboto', sans-serif;
+        }
+
+        /* Sidebar */
+        .sidebar {
+            width: 280px;
+            background: var(--bg-sidebar);
+            color: var(--text-white);
+            padding: 0;
+            position: fixed;
+            height: 100vh;
+            left: 0;
+            top: 72px;
+            z-index: 100;
+            display: flex;
+            flex-direction: column;
+            box-shadow: var(--shadow-lg);
+            transition: all 0.3s ease;
+        }
+
+        .sidebar-content {
+            flex: 1;
+            overflow-y: auto;
+            padding: 24px 0;
+        }
+
+        .nav-section {
+            margin-bottom: 32px;
+        }
+
+        .nav-section-title {
+            font-size: 12px;
+            font-weight: 600;
+            color: rgba(255, 255, 255, 0.5);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 16px;
+            padding: 0 24px;
+        }
+
+        .nav-item {
+            display: flex;
+            align-items: center;
+            padding: 12px 24px;
+            color: rgba(255, 255, 255, 0.8);
+            text-decoration: none;
+            transition: all 0.2s ease;
+            font-weight: 500;
+            border-right: 3px solid transparent;
+        }
+
+        .nav-item:hover {
+            background: rgba(255, 255, 255, 0.05);
+            color: var(--text-white);
+        }
+
+        .nav-item.active {
+            background: rgba(59, 130, 246, 0.1);
+            color: #3B82F6;
+            border-right-color: #3B82F6;
+        }
+
+        .nav-item i {
+            width: 20px;
+            margin-right: 12px;
+            font-size: 16px;
+        }
+
+        /* Main content */
+        .main-content {
+            flex: 1;
+            margin-left: 280px;
+            margin-top: 72px;
+            padding: 32px;
+            max-width: calc(100vw - 280px);
+        }
+
+        /* Header */
+        .header {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px 32px;
+            margin-bottom: 32px;
+            box-shadow: var(--shadow);
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .header-left h1 {
+            font-size: 28px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+            font-family: 'Roboto', sans-serif;
+        }
+
+        .header-left p {
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
+        /* Stats Section */
+        .stats-section {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 20px;
+            margin-bottom: 32px;
+        }
+
+        .stat-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            box-shadow: var(--shadow);
+            transition: all 0.2s ease;
+            text-align: center;
+        }
+
+        .stat-card:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-md);
+        }
+
+        .stat-card i {
+            font-size: 32px;
+            margin-bottom: 16px;
+            color: var(--accent);
+        }
+
+        .stat-value {
+            font-size: 24px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+        }
+
+        .stat-label {
+            color: var(--text-secondary);
+            font-size: 14px;
+        }
+
+        /* Wheel Section */
+        .wheel-section {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 40px;
+            margin-bottom: 32px;
+            box-shadow: var(--shadow);
+            text-align: center;
+        }
+
+        .wheel-title {
+            font-size: 24px;
+            font-weight: 700;
+            color: var(--text-primary);
+            margin-bottom: 32px;
+        }
+
+        .wheel-container {
+            position: relative;
+            display: inline-block;
+            margin: 0 auto 32px;
+        }
+
+        .wheel {
+            width: 300px;
+            height: 300px;
+            border-radius: 50%;
+            position: relative;
+            overflow: hidden;
+            border: 8px solid var(--border);
+            box-shadow: var(--shadow-lg);
+            transition: transform 3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+        }
+
+        .wheel-segment {
+            position: absolute;
+            width: 50%;
+            height: 50%;
+            transform-origin: 100% 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 600;
+            font-size: 14px;
+            color: white;
+            text-shadow: 0 1px 2px rgba(0,0,0,0.5);
+        }
+
+        .wheel-segment:nth-child(1) { background: var(--accent); transform: rotate(0deg); }
+        .wheel-segment:nth-child(2) { background: var(--success); transform: rotate(45deg); }
+        .wheel-segment:nth-child(3) { background: var(--warning); transform: rotate(90deg); }
+        .wheel-segment:nth-child(4) { background: var(--purple); transform: rotate(135deg); }
+        .wheel-segment:nth-child(5) { background: var(--pink); transform: rotate(180deg); }
+        .wheel-segment:nth-child(6) { background: var(--orange); transform: rotate(225deg); }
+        .wheel-segment:nth-child(7) { background: var(--danger); transform: rotate(270deg); }
+        .wheel-segment:nth-child(8) { background: #6366F1; transform: rotate(315deg); }
+
+        .wheel-pointer {
+            position: absolute;
+            top: -10px;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 0;
+            height: 0;
+            border-left: 15px solid transparent;
+            border-right: 15px solid transparent;
+            border-bottom: 30px solid var(--text-primary);
+            z-index: 10;
+        }
+
+        .wheel-center {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            width: 80px;
+            height: 80px;
+            background: var(--bg-card);
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            box-shadow: var(--shadow-lg);
+            z-index: 10;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            border: 4px solid var(--border);
+        }
+
+        .wheel-center:hover {
+            transform: translate(-50%, -50%) scale(1.1);
+        }
+
+        .spin-btn {
+            background: linear-gradient(135deg, var(--accent), var(--purple));
+            color: white;
+            border: none;
+            padding: 16px 32px;
+            border-radius: var(--radius-lg);
+            font-weight: 600;
+            cursor: pointer;
+            font-size: 16px;
+            transition: all 0.2s ease;
+            box-shadow: var(--shadow-md);
+            margin-bottom: 16px;
+        }
+
+        .spin-btn:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-lg);
+        }
+
+        .spin-btn:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+            transform: none;
+        }
+
+        .status-text {
+            color: var(--text-secondary);
+            font-size: 14px;
+            margin-top: 16px;
+        }
+
+        /* Prize Cards */
+        .prizes-section {
+            margin-bottom: 32px;
+        }
+
+        .section-title {
+            font-size: 22px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 24px;
+        }
+
+        .prizes-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+            gap: 16px;
+        }
+
+        .prize-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 20px;
+            text-align: center;
+            box-shadow: var(--shadow);
+            transition: all 0.2s ease;
+        }
+
+        .prize-card:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--shadow-md);
+        }
+
+        .prize-icon {
+            font-size: 24px;
+            margin-bottom: 12px;
+        }
+
+        .prize-title {
+            font-size: 14px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 4px;
+        }
+
+        .prize-value {
+            font-size: 16px;
+            font-weight: 700;
+            color: var(--success);
+        }
+
+        /* History Section */
+        .history-section {
+            background: var(--bg-card);
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 24px;
+            box-shadow: var(--shadow);
+        }
+
+        .history-item {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            padding: 16px 0;
+            border-bottom: 1px solid var(--border-light);
+        }
+
+        .history-item:last-child {
+            border-bottom: none;
+        }
+
+        .history-left {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+
+        .history-icon {
+            width: 40px;
+            height: 40px;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: white;
+            font-size: 16px;
+        }
+
+        .history-details h4 {
+            font-size: 14px;
+            font-weight: 600;
+            color: var(--text-primary);
+            margin-bottom: 2px;
+        }
+
+        .history-details p {
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        .history-value {
+            font-size: 16px;
+            font-weight: 700;
+            color: var(--success);
+        }
+
+        /* Responsive */
+        @media (max-width: 1024px) {
+            .sidebar {
+                transform: translateX(-100%);
+                transition: transform 0.3s ease;
+            }
+            
+            .sidebar.open {
+                transform: translateX(0);
+            }
+            
+            .main-content {
+                margin-left: 0;
+                max-width: 100vw;
+                padding: 20px;
+            }
+            
+            .hamburger {
+                display: flex;
+            }
+
+            .wheel {
+                width: 250px;
+                height: 250px;
+            }
+
+            .wheel-center {
+                width: 60px;
+                height: 60px;
+            }
+        }
+
+        /* Animations */
+        @keyframes sparkle {
+            0%, 100% { opacity: 1; transform: scale(1); }
+            50% { opacity: 0.7; transform: scale(1.1); }
+        }
+
+        .sparkle {
+            animation: sparkle 1s ease-in-out infinite;
+        }
+
+        @keyframes celebration {
+            0% { transform: scale(1) rotate(0deg); }
+            25% { transform: scale(1.1) rotate(5deg); }
+            50% { transform: scale(1.2) rotate(-5deg); }
+            75% { transform: scale(1.1) rotate(5deg); }
+            100% { transform: scale(1) rotate(0deg); }
+        }
+
+        .celebrate {
+            animation: celebration 0.6s ease-in-out;
+        }
+    </style>
+</head>
+
+<body>
+    <!-- Fixed Header -->
+    <header class="fixed-header">
+        <div class="header-left">
+            <button class="hamburger" onclick="toggleSidebar()">
+                <i class="fas fa-bars"></i>
+            </button>
+            <div class="header-title">FinverPro</div>
+        </div>
+    </header>
+
+    <!-- Sidebar -->
+    <nav class="sidebar" id="sidebar">
+        <div class="sidebar-content">
+            <div class="nav-section">
+                <div class="nav-section-title">Básico</div>
+                <a href="../dashboard/" class="nav-item">
+                    <i class="fas fa-home"></i>
+                    Início
+                </a>
+                <a href="../equipe/" class="nav-item">
+                    <i class="fas fa-users"></i>
+                    Equipe
+                </a>
+                <a href="../perfil/" class="nav-item">
+                    <i class="fas fa-user-circle"></i>
+                    Perfil
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Investimentos</div>
+                <a href="../investimentos/" class="nav-item">
+                    <i class="fas fa-coins"></i>
+                    Produtos
+                </a>
+                <a href="../investimentos/" class="nav-item">
+                    <i class="fas fa-chart-line"></i>
+                    Meus Investimentos
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Diversão</div>
+                <a href="#" class="nav-item active">
+                    <i class="fas fa-magic"></i>
+                    Roleta da Sorte
+                </a>
+            </div>
+
+            <div class="nav-section">
+                <div class="nav-section-title">Estatísticas</div>
+                <a href="../relatorios/" class="nav-item">
+                    <i class="fas fa-chart-bar"></i>
+                    Relatórios
+                </a>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Main Content -->
+    <main class="main-content">
+        <!-- Header -->
+        <div class="header">
+            <div class="header-left">
+                <h1>🎰 Roleta da Sorte</h1>
+                <p>Gire e ganhe prêmios incríveis todos os dias!</p>
+            </div>
+        </div>
+
+        <!-- Stats Section -->
+        <section class="stats-section">
+            <div class="stat-card">
+                <i class="fas fa-play-circle"></i>
+                <div class="stat-value" id="giros-disponiveis">3</div>
+                <div class="stat-label">Giros Disponíveis</div>
+            </div>
+
+            <div class="stat-card">
+                <i class="fas fa-calendar-day"></i>
+                <div class="stat-value" id="giros-hoje">2</div>
+                <div class="stat-label">Giros Hoje</div>
+            </div>
+
+            <div class="stat-card">
+                <i class="fas fa-clock"></i>
+                <div class="stat-value">5</div>
+                <div class="stat-label">Limite Diário</div>
+            </div>
+
+            <div class="stat-card">
+                <i class="fas fa-gift"></i>
+                <div class="stat-value">R$ 245</div>
+                <div class="stat-label">Total Ganho</div>
+            </div>
+        </section>
+
+        <!-- Wheel Section -->
+        <section class="wheel-section">
+            <h2 class="wheel-title">🌟 Gire a Roleta Cósmica</h2>
+            
+            <div class="wheel-container">
+                <div class="wheel-pointer"></div>
+                <div class="wheel" id="roulette-wheel">
+                    <div class="wheel-segment">R$ 10</div>
+                    <div class="wheel-segment">R$ 25</div>
+                    <div class="wheel-segment">R$ 50</div>
+                    <div class="wheel-segment">R$ 100</div>
+                    <div class="wheel-segment">Bônus</div>
+                    <div class="wheel-segment">R$ 75</div>
+                    <div class="wheel-segment">R$ 15</div>
+                    <div class="wheel-segment">R$ 200</div>
+                </div>
+                <div class="wheel-center" onclick="spinWheel()">
+                    <i class="fas fa-rocket" style="font-size: 24px; color: var(--accent);"></i>
+                </div>
+            </div>
+
+            <button class="spin-btn" id="spin-button" onclick="spinWheel()">
+                <i class="fas fa-magic"></i>
+                Girar Roleta
+            </button>
+            
+            <div class="status-text" id="status-text">
+                Clique no botão para girar através do cosmos!
+            </div>
+        </section>
+
+        <!-- Prizes Section -->
+        <section class="prizes-section">
+            <h2 class="section-title">🎁 Prêmios Disponíveis</h2>
+            
+            <div class="prizes-grid">
+                <div class="prize-card">
+                    <div class="prize-icon" style="color: var(--accent);">💰</div>
+                    <div class="prize-title">Dinheiro</div>
+                    <div class="prize-value">R$ 10 - 200</div>
+                </div>
+
+                <div class="prize-card">
+                    <div class="prize-icon" style="color: var(--success);">🎁</div>
+                    <div class="prize-title">Bônus</div>
+                    <div class="prize-value">5% - 20%</div>
+                </div>
+
+                <div class="prize-card">
+                    <div class="prize-icon" style="color: var(--purple);">⭐</div>
+                    <div class="prize-title">Giros Extra</div>
+                    <div class="prize-value">1 - 3 giros</div>
+                </div>
+
+                <div class="prize-card">
+                    <div class="prize-icon" style="color: var(--warning);">🏆</div>
+                    <div class="prize-title">Jackpot</div>
+                    <div class="prize-value">R$ 500</div>
+                </div>
+            </div>
+        </section>
+
+        <!-- History Section -->
+        <section class="history-section">
+            <h2 class="section-title">📊 Histórico Recente</h2>
+            
+            <div class="history-list">
+                <div class="history-item">
+                    <div class="history-left">
+                        <div class="history-icon" style="background: var(--success);">
+                            <i class="fas fa-gift"></i>
+                        </div>
+                        <div class="history-details">
+                            <h4>Prêmio Ganho</h4>
+                            <p>Há 2 horas</p>
+                        </div>
+                    </div>
+                    <div class="history-value">R$ 50,00</div>
+                </div>
+
+                <div class="history-item">
+                    <div class="history-left">
+                        <div class="history-icon" style="background: var(--accent);">
+                            <i class="fas fa-coins"></i>
+                        </div>
+                        <div class="history-details">
+                            <h4>Prêmio Ganho</h4>
+                            <p>Ontem</p>
+                        </div>
+                    </div>
+                    <div class="history-value">R$ 25,00</div>
+                </div>
+
+                <div class="history-item">
+                    <div class="history-left">
+                        <div class="history-icon" style="background: var(--purple);">
+                            <i class="fas fa-star"></i>
+                        </div>
+                        <div class="history-details">
+                            <h4>Bônus Especial</h4>
+                            <p>2 dias atrás</p>
+                        </div>
+                    </div>
+                    <div class="history-value">R$ 100,00</div>
+                </div>
+
+                <div class="history-item">
+                    <div class="history-left">
+                        <div class="history-icon" style="background: var(--warning);">
+                            <i class="fas fa-trophy"></i>
+                        </div>
+                        <div class="history-details">
+                            <h4>Giros Extra</h4>
+                            <p>3 dias atrás</p>
+                        </div>
+                    </div>
+                    <div class="history-value">+2 Giros</div>
+                </div>
+
+                <div class="history-item">
+                    <div class="history-left">
+                        <div class="history-icon" style="background: var(--danger);">
+                            <i class="fas fa-gem"></i>
+                        </div>
+                        <div class="history-details">
+                            <h4>Super Prêmio</h4>
+                            <p>1 semana atrás</p>
+                        </div>
+                    </div>
+                    <div class="history-value">R$ 200,00</div>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <script>
+        let isSpinning = false;
+        let girosDisponiveis = 3;
+
+        // Sidebar toggle for mobile
+        function toggleSidebar() {
+            const sidebar = document.getElementById('sidebar');
+            sidebar.classList.toggle('open');
+        }
+
+        // Wheel spinning function
+        function spinWheel() {
+            if (isSpinning || girosDisponiveis <= 0) {
+                return;
+            }
+
+            isSpinning = true;
+            girosDisponiveis--;
+            
+            // Update UI
+            document.getElementById('giros-disponiveis').textContent = girosDisponiveis;
+            document.getElementById('spin-button').disabled = true;
+            document.getElementById('status-text').textContent = 'Girando através do cosmos... 🌌';
+
+            const wheel = document.getElementById('roulette-wheel');
+            const prizes = ['R$ 10', 'R$ 25', 'R$ 50', 'R$ 100', 'Bônus', 'R$ 75', 'R$ 15', 'R$ 200'];
+            
+            // Random rotation (multiple full spins + random position)
+            const spins = 5 + Math.random() * 5; // 5-10 full rotations
+            const finalRotation = spins * 360 + (Math.random() * 360);
+            
+            wheel.style.transform = `rotate(${finalRotation}deg)`;
+            
+            // Calculate winning prize
+            const normalizedRotation = finalRotation % 360;
+            const segmentAngle = 360 / 8;
+            const winningSegment = Math.floor((360 - normalizedRotation + segmentAngle/2) / segmentAngle) % 8;
+            const winningPrize = prizes[winningSegment];
+
+            setTimeout(() => {
+                isSpinning = false;
+                document.getElementById('spin-button').disabled = false;
+                
+                // Show winning result
+                showPrizeModal(winningPrize);
+                
+                // Update status
+                if (girosDisponiveis > 0) {
+                    document.getElementById('status-text').textContent = `Parabéns! Você ganhou ${winningPrize}! Ainda restam ${girosDisponiveis} giros.`;
+                } else {
+                    document.getElementById('status-text').textContent = 'Você usou todos os giros de hoje! Volte amanhã para mais.';
+                }
+                
+                // Add celebration effect
+                wheel.classList.add('celebrate');
+                setTimeout(() => {
+                    wheel.classList.remove('celebrate');
+                }, 600);
+                
+            }, 3000);
+        }
+
+        // Prize modal function
+        function showPrizeModal(prize) {
+            // Create modal overlay
+            const modal = document.createElement('div');
+            modal.style.cssText = `
+                position: fixed;
+                top: 0;
+                left: 0;
+                right: 0;
+                bottom: 0;
+                background: rgba(0,0,0,0.8);
+                display: flex;
+                align-items: center;
+                justify-content: center;
+                z-index: 10000;
+                animation: fadeIn 0.3s ease;
+            `;
+
+            const modalContent = document.createElement('div');
+            modalContent.style.cssText = `
+                background: var(--bg-card);
+                border-radius: var(--radius-lg);
+                padding: 40px;
+                text-align: center;
+                max-width: 400px;
+                margin: 20px;
+                box-shadow: var(--shadow-lg);
+                animation: slideIn 0.3s ease;
+            `;
+
+            modalContent.innerHTML = `
+                <div style="font-size: 64px; margin-bottom: 20px;">🎉</div>
+                <h2 style="font-size: 24px; font-weight: 700; color: var(--text-primary); margin-bottom: 16px;">
+                    Parabéns!
+                </h2>
+                <p style="font-size: 18px; color: var(--text-secondary); margin-bottom: 24px;">
+                    Você ganhou:
+                </p>
+                <div style="font-size: 32px; font-weight: 800; color: var(--success); margin-bottom: 32px;">
+                    ${prize}
+                </div>
+                <button onclick="this.closest('[style*=\"position: fixed\"]').remove()" 
+                        style="background: var(--accent); color: white; border: none; padding: 12px 24px; 
+                               border-radius: var(--radius); font-weight: 600; cursor: pointer; font-size: 16px;">
+                    Ótimo!
+                </button>
+            `;
+
+            // Add CSS animations
+            const style = document.createElement('style');
+            style.textContent = `
+                @keyframes fadeIn {
+                    from { opacity: 0; }
+                    to { opacity: 1; }
+                }
+                @keyframes slideIn {
+                    from { transform: translateY(-50px) scale(0.9); opacity: 0; }
+                    to { transform: translateY(0) scale(1); opacity: 1; }
+                }
+            `;
+            document.head.appendChild(style);
+
+            modal.appendChild(modalContent);
+            document.body.appendChild(modal);
+
+            // Remove modal when clicking outside
+            modal.addEventListener('click', (e) => {
+                if (e.target === modal) {
+                    modal.remove();
+                }
+            });
+        }
+
+        // Close sidebar when clicking outside on mobile
+        document.addEventListener('click', function(event) {
+            const sidebar = document.getElementById('sidebar');
+            const hamburger = document.querySelector('.hamburger');
+            
+            if (window.innerWidth <= 1024 && !sidebar.contains(event.target) && !hamburger.contains(event.target)) {
+                sidebar.classList.remove('open');
+            }
+        });
+
+        // Responsive handling
+        window.addEventListener('resize', function() {
+            const sidebar = document.getElementById('sidebar');
+            if (window.innerWidth > 1024) {
+                sidebar.classList.remove('open');
+            }
+        });
+
+        // Add sparkle effect to prizes
+        setInterval(() => {
+            const prizeCards = document.querySelectorAll('.prize-card');
+            const randomCard = prizeCards[Math.floor(Math.random() * prizeCards.length)];
+            randomCard.classList.add('sparkle');
+            setTimeout(() => {
+                randomCard.classList.remove('sparkle');
+            }, 1000);
+        }, 3000);
+    </script>
+</body>
+</html>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Create a `design/` folder with recreated and adapted UI pages for the FinverPro system, excluding user-specific login/registration.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The user requested to recreate existing designs and adapt them, specifically mentioning a "roleta" (roulette) part and the removal of user-specific sections (cadastro/login). This PR delivers a set of responsive HTML/CSS/JS pages (dashboard, roulette, investments, team, profile, reports) in a dedicated `design/` directory, adhering to these requirements.